### PR TITLE
Adjust footer to appear only at page end

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,10 @@
             color: #2c3e50;
             line-height: 1.5;
             padding: 2rem;
-            padding-bottom: 6rem;
             margin: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
         }
 
         h1 {
@@ -91,11 +93,8 @@
             font-size: 0.85rem;
             border-top: 1px solid #e5e7eb;
             font-weight: 500;
-            position: fixed;
-            bottom: 0;
-            left: 0;
+            margin-top: auto;
             width: 100%;
-            z-index: 100;
         }
 
         .footer-content {

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -17,8 +17,9 @@
             min-height: 100vh;
             color: #1e293b;
             line-height: 1.6;
-            padding-bottom: 6rem;
             margin: 0;
+            display: flex;
+            flex-direction: column;
         }
 
         .container {
@@ -290,11 +291,8 @@
             font-size: 0.85rem;
             border-top: 1px solid #e5e7eb;
             font-weight: 500;
-            position: fixed;
-            bottom: 0;
-            left: 0;
+            margin-top: auto;
             width: 100%;
-            z-index: 100;
         }
 
         @media (max-width: 768px) {

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -17,8 +17,10 @@
             color: #2c3e50;
             background: #f8f9fa;
             font-size: 15px;
-            padding-bottom: 6rem;
             margin: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
         }
 
         .container {
@@ -204,11 +206,8 @@
             font-size: 0.85rem;
             border-top: 1px solid #e5e7eb;
             font-weight: 500;
-            position: fixed;
-            bottom: 0;
-            left: 0;
+            margin-top: auto;
             width: 100%;
-            z-index: 100;
         }
 
         #black-market-cash {

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -18,8 +18,9 @@
             line-height: 1.5;
             min-height: 100vh;
             transition: all 0.3s ease;
-            padding-bottom: 6rem;
             margin: 0;
+            display: flex;
+            flex-direction: column;
         }
 
         body.dark-theme {
@@ -443,11 +444,8 @@
             font-size: 0.85rem;
             border-top: 1px solid #e5e7eb;
             font-weight: 500;
-            position: fixed;
-            bottom: 0;
-            left: 0;
+            margin-top: auto;
             width: 100%;
-            z-index: 100;
         }
 
         .dark-theme .footer {

--- a/styles.css
+++ b/styles.css
@@ -30,8 +30,10 @@
     color: var(--text);
     transition: var(--transition);
     scroll-behavior: smooth;
-    padding-bottom: 6rem;
     margin: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
   }
   
   /* Headings */
@@ -593,16 +595,12 @@
   
   /* Footer */
   footer {
-    margin-top: 3rem;
     padding: 2rem;
     background-color: var(--secondary);
     text-align: center;
     color: rgba(255,255,255,0.7);
-    position: fixed;
-    bottom: 0;
-    left: 0;
     width: 100%;
-    z-index: 100;
+    margin-top: auto;
   }
   
   footer p {


### PR DESCRIPTION
## Summary
- update all pages to remove fixed-position footer and use flexbox layout
- adjust global styles for footer
- ensure body content fills viewport

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_687338558bcc8328963f61d086a89c4f