### PR TITLE
Centralize calculators and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,14 @@
                 <li><a href="pages/T10-calculator.html">Tier 10 Calculator</a></li>
                 <li><a href="pages/black-market-S1.html">Black Market Guide</a></li>
             </ul>
-        </nav>
+</nav>
     </header>
+    <div class="toggle-container container">
+        <span class="toggle-label">Dark Mode</span>
+        <div class="theme-toggle" id="themeToggle">
+            <div class="toggle-thumb"></div>
+        </div>
+    </div>
 <main class="content">
     <div class="hero">
         <h1>Last War Resources</h1>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -355,7 +355,13 @@
                 <li><a href="../pages/black-market-S1.html">Black Market Guide</a></li>
             </ul>
         </nav>
-    </header>
+</header>
+    <div class="toggle-container container">
+        <span class="toggle-label">Dark Mode</span>
+        <div class="theme-toggle" id="themeToggle">
+            <div class="toggle-thumb"></div>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <h1>Last War: Survival</h1>
@@ -472,7 +478,7 @@
             </div>
         </div>
 
-        <button class="reset-button" onclick="resetAll()">
+        <button class="reset-button">
             <span class="icon">🔄</span>Reset All to Level 0
         </button>
 
@@ -520,221 +526,7 @@
         </div>
     </footer>
 
-    <script>
-        const advancedProtectionGold = [
-            64600000,92300000,92300000,158000000,158000000,221000000,221000000,287000000,287000000,403000000
-        ];
-
-        const advancedProtectionValor = [
-            1280,1440,1440,1600,1600,1800,1800,2000,2000,2000
-        ];
-
-        const advancedProtectionFoodIron = [
-            21700000,31000000,31000000,53000000,53000000,74000000,74000000,96000000,96000000,134000000
-        ];
-
-        const boostThreeGold = [
-            92300000,158000000,158000000,221000000,221000000,287000000,287000000,403000000,403000000,563000000
-        ];
-
-        const boostThreeFoodIron = [
-            31000000,53000000,53000000,74000000,74000000,96000000,96000000,134000000,134000000,175000000
-        ];
-
-        const boostThreeValor = [
-            1440,1600,1600,1800,1800,2000,2000,2200,2200,2400
-        ];
-
-        const tierTenGold = 563000000;
-        const tierTenFoodIron = 188000000;
-        const tierTenValor = 2400;
-
-        // Maximum totals for progress bars
-        const maxTotalGold = 2767800000;
-        const maxTotalValor = 16960;
-        const maxTotalFoodIron = 922000000;
-
-        const advProtLvl = document.getElementById('adv-prot-lvl');
-        const hLvl = document.getElementById('healthLvl');
-        const aLvl = document.getElementById('attackLvl');
-        const dLvl = document.getElementById('defenseLvl');
-        
-        // Labels
-        const goldLabel = "💰 Gold";
-        const valorLabel = "🏆 Valor Badges";
-        const foodLabel = "🍖 Food";
-        const ironLabel = "⚙️ Iron";
-
-        let protVal, protGold, protFood, protIron = 0;
-        let healthVal, healthGold, healthFood, healthIron = 0;
-        let attackVal, attackGold, attackFood, attackIron = 0;
-        let defenseVal, defenseGold, defenseFood, defenseIron = 0;
-
-        // Result divs
-        const advProtGoldResultDiv = document.getElementById('advProtGoldResultDiv');
-        const advProtValorResultDiv = document.getElementById('advProtValorResultDiv');
-        const advProtFoodResultDiv = document.getElementById('advProtFoodResultDiv');
-        const advProtIronResultDiv = document.getElementById('advProtIronResultDiv');
-
-        const healthGoldResultDiv = document.getElementById('healthGoldResultDiv');
-        const healthValorResultDiv = document.getElementById('healthValorResultDiv');
-        const healthFoodResultDiv = document.getElementById('healthFoodResultDiv');
-        const healthIronResultDiv = document.getElementById('healthIronResultDiv');
-
-        const attackGoldResultDiv = document.getElementById('attackGoldResultDiv');
-        const attackValorResultDiv = document.getElementById('attackValorResultDiv');
-        const attackFoodResultDiv = document.getElementById('attackFoodResultDiv');
-        const attackIronResultDiv = document.getElementById('attackIronResultDiv');
-
-        const defenseGoldResultDiv = document.getElementById('defenseGoldResultDiv');
-        const defenseValorResultDiv = document.getElementById('defenseValorResultDiv');
-        const defenseFoodResultDiv = document.getElementById('defenseFoodResultDiv');
-        const defenseIronResultDiv = document.getElementById('defenseIronResultDiv');
-
-        const totalGoldDiv = document.getElementById('totalGoldRemainingDiv');
-        const totalValorDiv = document.getElementById('totalValorRemainingDiv');
-        const totalFoodDiv = document.getElementById('totalFoodRemainingDiv');
-        const totalIronDiv = document.getElementById('totalIronRemainingDiv');
-
-        // Progress bars
-        const goldProgress = document.getElementById('goldProgress');
-        const valorProgress = document.getElementById('valorProgress');
-        const foodProgress = document.getElementById('foodProgress');
-        const ironProgress = document.getElementById('ironProgress');
-
-        document.addEventListener('DOMContentLoaded', () => {
-            initializeCalculator();
-        });
-
-        function initializeCalculator() {
-            protGold = updateDiv(advProtLvl.value, advancedProtectionGold, advProtGoldResultDiv, goldLabel);
-            protVal = updateDiv(advProtLvl.value, advancedProtectionValor, advProtValorResultDiv, valorLabel);
-            protFood = updateDiv(advProtLvl.value, advancedProtectionFoodIron, advProtFoodResultDiv, foodLabel);
-            protIron = updateDiv(advProtLvl.value, advancedProtectionFoodIron, advProtIronResultDiv, ironLabel);
-
-            healthGold = updateDiv(hLvl.value, boostThreeGold, healthGoldResultDiv, goldLabel);
-            healthVal = updateDiv(hLvl.value, boostThreeValor, healthValorResultDiv, valorLabel);
-            healthFood = updateDiv(hLvl.value, boostThreeFoodIron, healthFoodResultDiv, foodLabel);
-            healthIron = updateDiv(hLvl.value, boostThreeFoodIron, healthIronResultDiv, ironLabel);
-
-            attackGold = updateDiv(aLvl.value, boostThreeGold, attackGoldResultDiv, goldLabel);
-            attackVal = updateDiv(aLvl.value, boostThreeValor, attackValorResultDiv, valorLabel);
-            attackFood = updateDiv(aLvl.value, boostThreeFoodIron, attackFoodResultDiv, foodLabel);
-            attackIron = updateDiv(aLvl.value, boostThreeFoodIron, attackIronResultDiv, ironLabel);
-            
-            defenseGold = updateDiv(dLvl.value, boostThreeGold, defenseGoldResultDiv, goldLabel);
-            defenseVal = updateDiv(dLvl.value, boostThreeValor, defenseValorResultDiv, valorLabel);
-            defenseFood = updateDiv(dLvl.value, boostThreeFoodIron, defenseFoodResultDiv, foodLabel);
-            defenseIron = updateDiv(dLvl.value, boostThreeFoodIron, defenseIronResultDiv, ironLabel);
-
-            updateTotals();
-        }
-
-        advProtLvl.addEventListener('change', (event) => {
-            protGold = updateDiv(event.target.value, advancedProtectionGold, advProtGoldResultDiv, goldLabel);
-            protVal = updateDiv(event.target.value, advancedProtectionValor, advProtValorResultDiv, valorLabel);
-            protFood = updateDiv(event.target.value, advancedProtectionFoodIron, advProtFoodResultDiv, foodLabel);
-            protIron = updateDiv(event.target.value, advancedProtectionFoodIron, advProtIronResultDiv, ironLabel);
-            updateTotals();
-        });
-
-        hLvl.addEventListener('change', (event) => {
-            healthGold = updateDiv(event.target.value, boostThreeGold, healthGoldResultDiv, goldLabel);
-            healthVal = updateDiv(event.target.value, boostThreeValor, healthValorResultDiv, valorLabel);
-            healthFood = updateDiv(event.target.value, boostThreeFoodIron, healthFoodResultDiv, foodLabel);
-            healthIron = updateDiv(event.target.value, boostThreeFoodIron, healthIronResultDiv, ironLabel);
-            updateTotals();
-        });
-
-        aLvl.addEventListener('change', (event) => {
-            attackGold = updateDiv(event.target.value, boostThreeGold, attackGoldResultDiv, goldLabel);
-            attackVal = updateDiv(event.target.value, boostThreeValor, attackValorResultDiv, valorLabel);
-            attackFood = updateDiv(event.target.value, boostThreeFoodIron, attackFoodResultDiv, foodLabel);
-            attackIron = updateDiv(event.target.value, boostThreeFoodIron, attackIronResultDiv, ironLabel);
-            updateTotals();
-        });
-
-        dLvl.addEventListener('change', (event) => {
-            defenseGold = updateDiv(event.target.value, boostThreeGold, defenseGoldResultDiv, goldLabel);
-            defenseVal = updateDiv(event.target.value, boostThreeValor, defenseValorResultDiv, valorLabel);
-            defenseFood = updateDiv(event.target.value, boostThreeFoodIron, defenseFoodResultDiv, foodLabel);
-            defenseIron = updateDiv(event.target.value, boostThreeFoodIron, defenseIronResultDiv, ironLabel);
-            updateTotals();
-        });
-
-        function updateDiv(newValue, valuesArray, targetDiv, resource) {
-            targetDiv.classList.add('updating');
-            setTimeout(() => {
-                let totaledValues = sumRange(valuesArray, newValue, valuesArray.length - 1);
-                targetDiv.textContent = totaledValues.toLocaleString() + " " + resource;
-                targetDiv.classList.remove('updating');
-            }, 100);
-            return sumRange(valuesArray, newValue, valuesArray.length - 1);
-        }
-
-        function updateTotals() {
-            // Update total values
-            let totalGoldNum = healthGold + protGold + attackGold + defenseGold + tierTenGold;
-            let totalValorNum = healthVal + protVal + attackVal + defenseVal + tierTenValor;
-            let totalFoodNum = healthFood + protFood + attackFood + defenseFood + tierTenFoodIron;
-            let totalIronNum = healthIron + protIron + attackIron + defenseIron + tierTenFoodIron;
-
-            // Update display with animation
-            animateValue(totalGoldDiv, totalGoldNum);
-            animateValue(totalValorDiv, totalValorNum);
-            animateValue(totalFoodDiv, totalFoodNum);
-            animateValue(totalIronDiv, totalIronNum);
-
-            // Update progress bars
-            updateProgressBar(goldProgress, maxTotalGold - totalGoldNum, maxTotalGold);
-            updateProgressBar(valorProgress, maxTotalValor - totalValorNum, maxTotalValor);
-            updateProgressBar(foodProgress, maxTotalFoodIron - totalFoodNum, maxTotalFoodIron);
-            updateProgressBar(ironProgress, maxTotalFoodIron - totalIronNum, maxTotalFoodIron);
-        }
-
-        function updateProgressBar(progressBar, current, max) {
-            const percentage = (current / max) * 100;
-            progressBar.style.width = percentage + '%';
-        }
-
-        function animateValue(element, targetValue) {
-            element.classList.add('updating');
-            setTimeout(() => {
-                element.textContent = targetValue.toLocaleString();
-                element.classList.remove('updating');
-            }, 100);
-        }
-
-        function sumRange(arr, start, end) {
-            if (start < 0 || end >= arr.length || start > end) {
-                return 0;
-            }
-
-            let sum = 0;
-            for (let i = start; i <= end; i++) {
-                sum += arr[i];
-            }
-            return sum;
-        }
-
-        function resetAll() {
-            // Reset all selects to 0
-            advProtLvl.value = '0';
-            hLvl.value = '0';
-            aLvl.value = '0';
-            dLvl.value = '0';
-            
-            // Reinitialize calculator
-            initializeCalculator();
-            
-            // Add visual feedback
-            document.querySelectorAll('.tech-node').forEach(node => {
-                node.style.transform = 'scale(0.98)';
-                setTimeout(() => {
-                    node.style.transform = 'scale(1)';
-                }, 150);
-            });
-        }
-    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -230,6 +230,12 @@
             </ul>
         </nav>
     </header>
+    <div class="toggle-container container">
+        <span class="toggle-label">Dark Mode</span>
+        <div class="theme-toggle" id="themeToggle">
+            <div class="toggle-thumb"></div>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <h1>Season 1 Black Market Guide</h1>
@@ -359,5 +365,7 @@
             <span>📅 2024</span>
         </div>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -453,7 +453,12 @@
             </ul>
         </nav>
     </header>
-    <button class="theme-toggle" onclick="toggleTheme()">🌙 Dark</button>
+    <div class="toggle-container container">
+        <span class="toggle-label">Dark Mode</span>
+        <div class="theme-toggle" id="themeToggle">
+            <div class="toggle-thumb"></div>
+        </div>
+    </div>
     
     <div class="header">
         <h1>Protein Farm Production Calculator</h1>
@@ -481,14 +486,13 @@
                             class="form-input" 
                             placeholder="Enter the red number from your progress bar"
                             min="1"
-                            oninput="calculateProduction()"
                         />
                     </div>
 
                     <div class="farm-grid">
                         <div class="farm-item" id="farm1-container">
                             <div class="farm-name">Protein Farm I</div>
-                            <select id="farm1" class="form-select" onchange="calculateProduction()">
+                            <select id="farm1" class="form-select">
                                 <!-- Options populated by JavaScript -->
                             </select>
                             <div class="production-info" id="farm1-info"></div>
@@ -496,7 +500,7 @@
 
                         <div class="farm-item" id="farm2-container">
                             <div class="farm-name">Protein Farm II</div>
-                            <select id="farm2" class="form-select" onchange="calculateProduction()">
+                            <select id="farm2" class="form-select">
                                 <option value="0">Not Built</option>
                                 <!-- Options populated by JavaScript -->
                             </select>
@@ -505,7 +509,7 @@
 
                         <div class="farm-item" id="farm3-container">
                             <div class="farm-name">Protein Farm III</div>
-                            <select id="farm3" class="form-select" onchange="calculateProduction()">
+                            <select id="farm3" class="form-select">
                                 <option value="0">Not Built</option>
                                 <!-- Options populated by JavaScript -->
                             </select>
@@ -514,7 +518,7 @@
 
                         <div class="farm-item" id="farm4-container">
                             <div class="farm-name">Protein Farm IV</div>
-                            <select id="farm4" class="form-select" onchange="calculateProduction()">
+                            <select id="farm4" class="form-select">
                                 <option value="0">Not Built</option>
                                 <!-- Options populated by JavaScript -->
                             </select>
@@ -523,7 +527,7 @@
 
                         <div class="farm-item" id="farm5-container">
                             <div class="farm-name">Protein Farm V</div>
-                            <select id="farm5" class="form-select" onchange="calculateProduction()">
+                            <select id="farm5" class="form-select">
                                 <option value="0">Not Built</option>
                                 <!-- Options populated by JavaScript -->
                             </select>
@@ -563,155 +567,7 @@
         </div>
     </footer>
 
-    <script>
-        // Production rates per hour by farm level
-        const productionRates = {
-            1: 720, 2: 1440, 3: 2160, 4: 2880, 5: 3600,
-            6: 4320, 7: 5040, 8: 5760, 9: 6480, 10: 7200,
-            11: 7920, 12: 8640, 13: 9360, 14: 10080, 15: 10800,
-            16: 11520, 17: 12240, 18: 12960, 19: 13680, 20: 14400,
-            21: 15120, 22: 15840, 23: 16560, 24: 17280, 25: 18000,
-            26: 18720, 27: 19440, 28: 20160, 29: 20880, 30: 21600
-        };
-
-        let isDarkTheme = false;
-
-        // Initialize calculator
-        function initializeCalculator() {
-            populateDropdowns();
-            calculateProduction();
-        }
-
-        // Populate farm level dropdowns
-        function populateDropdowns() {
-            const farm1 = document.getElementById('farm1');
-            
-            // Protein Farm I (always available, starts at level 1)
-            for (let i = 1; i <= 30; i++) {
-                const option = document.createElement('option');
-                option.value = i;
-                option.textContent = `Level ${i} (${productionRates[i].toLocaleString()}/hr)`;
-                farm1.appendChild(option);
-            }
-
-            // Farms II-V (can be not built or levels 1-30)
-            for (let farmNum = 2; farmNum <= 5; farmNum++) {
-                const farmSelect = document.getElementById(`farm${farmNum}`);
-                
-                for (let i = 1; i <= 30; i++) {
-                    const option = document.createElement('option');
-                    option.value = i;
-                    option.textContent = `Level ${i} (${productionRates[i].toLocaleString()}/hr)`;
-                    farmSelect.appendChild(option);
-                }
-            }
-        }
-
-        // Update production info for each farm
-        function updateProductionInfo() {
-            for (let i = 1; i <= 5; i++) {
-                const level = parseInt(document.getElementById(`farm${i}`).value) || 0;
-                const infoElement = document.getElementById(`farm${i}-info`);
-                const containerElement = document.getElementById(`farm${i}-container`);
-                
-                if (level > 0) {
-                    const rate = productionRates[level];
-                    infoElement.textContent = `${rate.toLocaleString()} units/hour`;
-                    containerElement.classList.add('active');
-                } else {
-                    infoElement.textContent = 'Not operational';
-                    containerElement.classList.remove('active');
-                }
-            }
-        }
-
-        // Calculate production metrics
-        function calculateProduction() {
-            updateProductionInfo();
-            
-            const targetAmount = parseInt(document.getElementById('targetAmount').value) || 0;
-            const resultsContent = document.getElementById('results-content');
-
-            if (targetAmount <= 0) {
-                resultsContent.innerHTML = `
-                    <div class="empty-state">
-                        <div class="empty-state-icon">📊</div>
-                        <p>Configure your farms and enter target amount</p>
-                    </div>
-                `;
-                return;
-            }
-
-            let totalProduction = 0;
-
-            // Calculate total production from all active farms
-            for (let i = 1; i <= 5; i++) {
-                const level = parseInt(document.getElementById(`farm${i}`).value) || 0;
-                if (level > 0) {
-                    totalProduction += productionRates[level];
-                }
-            }
-
-            if (totalProduction === 0) {
-                resultsContent.innerHTML = `
-                    <div class="empty-state">
-                        <div class="empty-state-icon">⚠️</div>
-                        <p>No active farms detected. Please configure at least one farm.</p>
-                    </div>
-                `;
-                return;
-            }
-
-            // Calculate time needed
-            const hoursNeeded = targetAmount / totalProduction;
-            const hours = Math.floor(hoursNeeded);
-            const minutes = Math.ceil((hoursNeeded - hours) * 60);
-            const days = Math.floor(hoursNeeded / 24);
-            const remainingHours = Math.floor(hoursNeeded % 24);
-
-            let timeDisplay;
-            if (days > 0) {
-                timeDisplay = `${days}d ${remainingHours}h ${minutes}m`;
-            } else if (hours === 0) {
-                timeDisplay = `${minutes} minutes`;
-            } else {
-                timeDisplay = `${hours}h ${minutes}m`;
-            }
-
-            // Display results
-            resultsContent.innerHTML = `
-                <div class="metric">
-                    <span class="metric-label">Total Production Rate</span>
-                    <span class="metric-value">${totalProduction.toLocaleString()}/hour</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">Target Amount</span>
-                    <span class="metric-value">${targetAmount.toLocaleString()} units</span>
-                </div>
-                <div class="time-estimate">
-                    <div class="time-value">${timeDisplay}</div>
-                    <div class="time-label">Estimated completion time</div>
-                </div>
-            `;
-        }
-
-        // Theme toggle functionality
-        function toggleTheme() {
-            isDarkTheme = !isDarkTheme;
-            const body = document.body;
-            const themeToggle = document.querySelector('.theme-toggle');
-            
-            if (isDarkTheme) {
-                body.classList.add('dark-theme');
-                themeToggle.textContent = '☀️ Light';
-            } else {
-                body.classList.remove('dark-theme');
-                themeToggle.textContent = '🌙 Dark';
-            }
-        }
-
-        // Initialize when page loads
-        document.addEventListener('DOMContentLoaded', initializeCalculator);
-    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,13 +1,17 @@
+function toggleDarkMode() {
+    $("body").toggleClass("dark-mode");
+    if ($("body").hasClass("dark-mode")) {
+        document.documentElement.setAttribute("data-theme", "dark");
+    } else {
+        document.documentElement.setAttribute("data-theme", "light");
+    }
+}
+window.toggleDarkMode = toggleDarkMode;
+
 $(document).ready(function() {
-    // Theme Toggle
-    $("#themeToggle").click(function() {
-        $("body").toggleClass("dark-mode");
-        if ($("body").hasClass("dark-mode")) {
-            document.documentElement.setAttribute("data-theme", "dark");
-        } else {
-            document.documentElement.setAttribute("data-theme", "light");
-        }
-    });
+    if (document.getElementById("themeToggle")) {
+        $("#themeToggle").on("click", toggleDarkMode);
+    }
     
     // Navigation Active State for links
     $(".nav-link").click(function() {
@@ -140,4 +144,281 @@ $(document).ready(function() {
         $(this).parent().find(".building-level").removeClass("active");
         $(this).addClass("active");
     });
+
+    if (document.getElementById("farm1")) {
+        initProteinCalculator();
+    }
+
+    if (document.getElementById("adv-prot-lvl")) {
+        initTier10Calculator();
+    }
 });
+
+function initProteinCalculator() {
+    const productionRates = {
+        1: 720, 2: 1440, 3: 2160, 4: 2880, 5: 3600,
+        6: 4320, 7: 5040, 8: 5760, 9: 6480, 10: 7200,
+        11: 7920, 12: 8640, 13: 9360, 14: 10080, 15: 10800,
+        16: 11520, 17: 12240, 18: 12960, 19: 13680, 20: 14400,
+        21: 15120, 22: 15840, 23: 16560, 24: 17280, 25: 18000,
+        26: 18720, 27: 19440, 28: 20160, 29: 20880, 30: 21600
+    };
+
+    function populateDropdowns() {
+        const farm1 = $("#farm1");
+        for (let i = 1; i <= 30; i++) {
+            farm1.append($('<option>').val(i).text(`Level ${i} (${productionRates[i].toLocaleString()}/hr)`));
+        }
+        for (let farmNum = 2; farmNum <= 5; farmNum++) {
+            const farmSelect = $(`#farm${farmNum}`);
+            for (let i = 1; i <= 30; i++) {
+                farmSelect.append($('<option>').val(i).text(`Level ${i} (${productionRates[i].toLocaleString()}/hr)`));
+            }
+        }
+    }
+
+    function updateProductionInfo() {
+        for (let i = 1; i <= 5; i++) {
+            const level = parseInt($(`#farm${i}`).val()) || 0;
+            const infoElement = $(`#farm${i}-info`);
+            const containerElement = $(`#farm${i}-container`);
+            if (level > 0) {
+                const rate = productionRates[level];
+                infoElement.text(`${rate.toLocaleString()} units/hour`);
+                containerElement.addClass('active');
+            } else {
+                infoElement.text('Not operational');
+                containerElement.removeClass('active');
+            }
+        }
+    }
+
+    function calculateProduction() {
+        updateProductionInfo();
+        const targetAmount = parseInt($("#targetAmount").val()) || 0;
+        const resultsContent = $("#results-content");
+        if (targetAmount <= 0) {
+            resultsContent.html(
+                `<div class="empty-state"><div class="empty-state-icon">📊</div><p>Configure your farms and enter target amount</p></div>`
+            );
+            return;
+        }
+
+        let totalProduction = 0;
+        for (let i = 1; i <= 5; i++) {
+            const level = parseInt($(`#farm${i}`).val()) || 0;
+            if (level > 0) {
+                totalProduction += productionRates[level];
+            }
+        }
+
+        if (totalProduction === 0) {
+            resultsContent.html(
+                `<div class="empty-state"><div class="empty-state-icon">⚠️</div><p>No active farms detected. Please configure at least one farm.</p></div>`
+            );
+            return;
+        }
+
+        const hoursNeeded = targetAmount / totalProduction;
+        const hours = Math.floor(hoursNeeded);
+        const minutes = Math.ceil((hoursNeeded - hours) * 60);
+        const days = Math.floor(hoursNeeded / 24);
+        const remainingHours = Math.floor(hoursNeeded % 24);
+
+        let timeDisplay;
+        if (days > 0) {
+            timeDisplay = `${days}d ${remainingHours}h ${minutes}m`;
+        } else if (hours === 0) {
+            timeDisplay = `${minutes} minutes`;
+        } else {
+            timeDisplay = `${hours}h ${minutes}m`;
+        }
+
+        resultsContent.html(
+            `<div class="metric"><span class="metric-label">Total Production Rate</span><span class="metric-value">${totalProduction.toLocaleString()}/hour</span></div>` +
+            `<div class="metric"><span class="metric-label">Target Amount</span><span class="metric-value">${targetAmount.toLocaleString()} units</span></div>` +
+            `<div class="time-estimate"><div class="time-value">${timeDisplay}</div><div class="time-label">Estimated completion time</div></div>`
+        );
+    }
+
+    populateDropdowns();
+    calculateProduction();
+
+    $("#targetAmount").on("input", calculateProduction);
+    $("#farm1, #farm2, #farm3, #farm4, #farm5").on("change", calculateProduction);
+}
+
+function initTier10Calculator() {
+    const advancedProtectionGold = [64600000,92300000,92300000,158000000,158000000,221000000,221000000,287000000,287000000,403000000];
+    const advancedProtectionValor = [1280,1440,1440,1600,1600,1800,1800,2000,2000,2000];
+    const advancedProtectionFoodIron = [21700000,31000000,31000000,53000000,53000000,74000000,74000000,96000000,96000000,134000000];
+    const boostThreeGold = [92300000,158000000,158000000,221000000,221000000,287000000,287000000,403000000,403000000,563000000];
+    const boostThreeFoodIron = [31000000,53000000,53000000,74000000,74000000,96000000,96000000,134000000,134000000,175000000];
+    const boostThreeValor = [1440,1600,1600,1800,1800,2000,2000,2200,2200,2400];
+    const tierTenGold = 563000000;
+    const tierTenFoodIron = 188000000;
+    const tierTenValor = 2400;
+    const maxTotalGold = 2767800000;
+    const maxTotalValor = 16960;
+    const maxTotalFoodIron = 922000000;
+
+    const advProtLvl = document.getElementById('adv-prot-lvl');
+    const hLvl = document.getElementById('healthLvl');
+    const aLvl = document.getElementById('attackLvl');
+    const dLvl = document.getElementById('defenseLvl');
+
+    const advProtGoldResultDiv = document.getElementById('advProtGoldResultDiv');
+    const advProtValorResultDiv = document.getElementById('advProtValorResultDiv');
+    const advProtFoodResultDiv = document.getElementById('advProtFoodResultDiv');
+    const advProtIronResultDiv = document.getElementById('advProtIronResultDiv');
+    const healthGoldResultDiv = document.getElementById('healthGoldResultDiv');
+    const healthValorResultDiv = document.getElementById('healthValorResultDiv');
+    const healthFoodResultDiv = document.getElementById('healthFoodResultDiv');
+    const healthIronResultDiv = document.getElementById('healthIronResultDiv');
+    const attackGoldResultDiv = document.getElementById('attackGoldResultDiv');
+    const attackValorResultDiv = document.getElementById('attackValorResultDiv');
+    const attackFoodResultDiv = document.getElementById('attackFoodResultDiv');
+    const attackIronResultDiv = document.getElementById('attackIronResultDiv');
+    const defenseGoldResultDiv = document.getElementById('defenseGoldResultDiv');
+    const defenseValorResultDiv = document.getElementById('defenseValorResultDiv');
+    const defenseFoodResultDiv = document.getElementById('defenseFoodResultDiv');
+    const defenseIronResultDiv = document.getElementById('defenseIronResultDiv');
+    const totalGoldDiv = document.getElementById('totalGoldRemainingDiv');
+    const totalValorDiv = document.getElementById('totalValorRemainingDiv');
+    const totalFoodDiv = document.getElementById('totalFoodRemainingDiv');
+    const totalIronDiv = document.getElementById('totalIronRemainingDiv');
+    const goldProgress = document.getElementById('goldProgress');
+    const valorProgress = document.getElementById('valorProgress');
+    const foodProgress = document.getElementById('foodProgress');
+    const ironProgress = document.getElementById('ironProgress');
+
+    function initializeCalculator() {
+        protGold = updateDiv(advProtLvl.value, advancedProtectionGold, advProtGoldResultDiv, '💰 Gold');
+        protVal = updateDiv(advProtLvl.value, advancedProtectionValor, advProtValorResultDiv, '🏆 Valor Badges');
+        protFood = updateDiv(advProtLvl.value, advancedProtectionFoodIron, advProtFoodResultDiv, '🍖 Food');
+        protIron = updateDiv(advProtLvl.value, advancedProtectionFoodIron, advProtIronResultDiv, '⚙️ Iron');
+
+        healthGold = updateDiv(hLvl.value, boostThreeGold, healthGoldResultDiv, '💰 Gold');
+        healthVal = updateDiv(hLvl.value, boostThreeValor, healthValorResultDiv, '🏆 Valor Badges');
+        healthFood = updateDiv(hLvl.value, boostThreeFoodIron, healthFoodResultDiv, '🍖 Food');
+        healthIron = updateDiv(hLvl.value, boostThreeFoodIron, healthIronResultDiv, '⚙️ Iron');
+
+        attackGold = updateDiv(aLvl.value, boostThreeGold, attackGoldResultDiv, '💰 Gold');
+        attackVal = updateDiv(aLvl.value, boostThreeValor, attackValorResultDiv, '🏆 Valor Badges');
+        attackFood = updateDiv(aLvl.value, boostThreeFoodIron, attackFoodResultDiv, '🍖 Food');
+        attackIron = updateDiv(aLvl.value, boostThreeFoodIron, attackIronResultDiv, '⚙️ Iron');
+
+        defenseGold = updateDiv(dLvl.value, boostThreeGold, defenseGoldResultDiv, '💰 Gold');
+        defenseVal = updateDiv(dLvl.value, boostThreeValor, defenseValorResultDiv, '🏆 Valor Badges');
+        defenseFood = updateDiv(dLvl.value, boostThreeFoodIron, defenseFoodResultDiv, '🍖 Food');
+        defenseIron = updateDiv(dLvl.value, boostThreeFoodIron, defenseIronResultDiv, '⚙️ Iron');
+
+        updateTotals();
+    }
+
+    function updateDiv(newValue, valuesArray, targetDiv, resource) {
+        targetDiv.classList.add('updating');
+        setTimeout(() => {
+            const totaled = sumRange(valuesArray, newValue, valuesArray.length - 1);
+            targetDiv.textContent = totaled.toLocaleString() + ' ' + resource;
+            targetDiv.classList.remove('updating');
+        }, 100);
+        return sumRange(valuesArray, newValue, valuesArray.length - 1);
+    }
+
+    function updateTotals() {
+        const totalGoldNum = healthGold + protGold + attackGold + defenseGold + tierTenGold;
+        const totalValorNum = healthVal + protVal + attackVal + defenseVal + tierTenValor;
+        const totalFoodNum = healthFood + protFood + attackFood + defenseFood + tierTenFoodIron;
+        const totalIronNum = healthIron + protIron + attackIron + defenseIron + tierTenFoodIron;
+
+        animateValue(totalGoldDiv, totalGoldNum);
+        animateValue(totalValorDiv, totalValorNum);
+        animateValue(totalFoodDiv, totalFoodNum);
+        animateValue(totalIronDiv, totalIronNum);
+
+        updateProgressBar(goldProgress, maxTotalGold - totalGoldNum, maxTotalGold);
+        updateProgressBar(valorProgress, maxTotalValor - totalValorNum, maxTotalValor);
+        updateProgressBar(foodProgress, maxTotalFoodIron - totalFoodNum, maxTotalFoodIron);
+        updateProgressBar(ironProgress, maxTotalFoodIron - totalIronNum, maxTotalFoodIron);
+    }
+
+    function updateProgressBar(progressBar, current, max) {
+        const percentage = (current / max) * 100;
+        progressBar.style.width = percentage + '%';
+    }
+
+    function animateValue(element, targetValue) {
+        element.classList.add('updating');
+        setTimeout(() => {
+            element.textContent = targetValue.toLocaleString();
+            element.classList.remove('updating');
+        }, 100);
+    }
+
+    function sumRange(arr, start, end) {
+        if (start < 0 || end >= arr.length || start > end) {
+            return 0;
+        }
+        let sum = 0;
+        for (let i = start; i <= end; i++) {
+            sum += arr[i];
+        }
+        return sum;
+    }
+
+    function resetAll() {
+        advProtLvl.value = '0';
+        hLvl.value = '0';
+        aLvl.value = '0';
+        dLvl.value = '0';
+        initializeCalculator();
+        document.querySelectorAll('.tech-node').forEach(node => {
+            node.style.transform = 'scale(0.98)';
+            setTimeout(() => {
+                node.style.transform = 'scale(1)';
+            }, 150);
+        });
+    }
+
+    let protVal = 0, protGold = 0, protFood = 0, protIron = 0;
+    let healthVal = 0, healthGold = 0, healthFood = 0, healthIron = 0;
+    let attackVal = 0, attackGold = 0, attackFood = 0, attackIron = 0;
+    let defenseVal = 0, defenseGold = 0, defenseFood = 0, defenseIron = 0;
+
+    initializeCalculator();
+
+    advProtLvl.addEventListener('change', e => {
+        protGold = updateDiv(e.target.value, advancedProtectionGold, advProtGoldResultDiv, '💰 Gold');
+        protVal = updateDiv(e.target.value, advancedProtectionValor, advProtValorResultDiv, '🏆 Valor Badges');
+        protFood = updateDiv(e.target.value, advancedProtectionFoodIron, advProtFoodResultDiv, '🍖 Food');
+        protIron = updateDiv(e.target.value, advancedProtectionFoodIron, advProtIronResultDiv, '⚙️ Iron');
+        updateTotals();
+    });
+
+    hLvl.addEventListener('change', e => {
+        healthGold = updateDiv(e.target.value, boostThreeGold, healthGoldResultDiv, '💰 Gold');
+        healthVal = updateDiv(e.target.value, boostThreeValor, healthValorResultDiv, '🏆 Valor Badges');
+        healthFood = updateDiv(e.target.value, boostThreeFoodIron, healthFoodResultDiv, '🍖 Food');
+        healthIron = updateDiv(e.target.value, boostThreeFoodIron, healthIronResultDiv, '⚙️ Iron');
+        updateTotals();
+    });
+
+    aLvl.addEventListener('change', e => {
+        attackGold = updateDiv(e.target.value, boostThreeGold, attackGoldResultDiv, '💰 Gold');
+        attackVal = updateDiv(e.target.value, boostThreeValor, attackValorResultDiv, '🏆 Valor Badges');
+        attackFood = updateDiv(e.target.value, boostThreeFoodIron, attackFoodResultDiv, '🍖 Food');
+        attackIron = updateDiv(e.target.value, boostThreeFoodIron, attackIronResultDiv, '⚙️ Iron');
+        updateTotals();
+    });
+
+    dLvl.addEventListener('change', e => {
+        defenseGold = updateDiv(e.target.value, boostThreeGold, defenseGoldResultDiv, '💰 Gold');
+        defenseVal = updateDiv(e.target.value, boostThreeValor, defenseValorResultDiv, '🏆 Valor Badges');
+        defenseFood = updateDiv(e.target.value, boostThreeFoodIron, defenseFoodResultDiv, '🍖 Food');
+        defenseIron = updateDiv(e.target.value, boostThreeFoodIron, defenseIronResultDiv, '⚙️ Iron');
+        updateTotals();
+    });
+
+    document.querySelector('.reset-button').addEventListener('click', resetAll);
+}


### PR DESCRIPTION
## Summary
- move page scripts into `script.js`
- add shared dark mode toggle and controls
- include script bundle on all pages

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_6873e5a14de0832880b8878986a52676