### PR TITLE
Remove custom dark-theme css

### DIFF
--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -30,38 +30,10 @@
             flex-direction: column;
         }
 
-        body.dark-theme {
-            background-color: #1a1a2e;
-            color: #e0e0e0;
-        }
 
-        .theme-toggle {
-            position: fixed;
-            top: 1rem;
-            right: 1rem;
-            background: #667eea;
-            color: white;
-            border: none;
-            border-radius: 6px;
-            padding: 0.5rem 1rem;
-            cursor: pointer;
-            font-weight: 500;
-            transition: all 0.3s ease;
-            z-index: 1000;
-            font-size: 0.9rem;
-        }
 
-        .theme-toggle:hover {
-            background: #5a67d8;
-        }
 
-        .dark-theme .theme-toggle {
-            background: #4a5568;
-        }
 
-        .dark-theme .theme-toggle:hover {
-            background: #2d3748;
-        }
 
         .header {
             background: linear-gradient(135deg, var(--primary), var(--primary-dark));
@@ -71,9 +43,6 @@
             box-shadow: 0 2px 10px rgba(0,0,0,0.1);
         }
 
-        .dark-theme .header {
-            background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
-        }
 
         .header h1 {
             font-size: 1.8rem;
@@ -109,11 +78,6 @@
             border: 1px solid var(--border);
         }
 
-        .dark-theme .card {
-            background: #16213e;
-            border-color: #2d3748;
-            color: #e0e0e0;
-        }
 
         .card-header {
             border-bottom: 1px solid var(--border);
@@ -121,9 +85,6 @@
             margin-bottom: 1.5rem;
         }
 
-        .dark-theme .card-header {
-            border-bottom-color: #2d3748;
-        }
 
         .card-title {
             font-size: 1.2rem;
@@ -132,9 +93,6 @@
             margin: 0;
         }
 
-        .dark-theme .card-title {
-            color: #e0e0e0;
-        }
 
         .progress-image {
             width: 100%;
@@ -147,10 +105,6 @@
             border: 2px solid var(--border);
         }
 
-        .dark-theme .progress-image {
-            border-color: #2d3748;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-        }
 
         .target-section {
             background: var(--bg);
@@ -160,10 +114,6 @@
             margin-bottom: 1.5rem;
         }
 
-        .dark-theme .target-section {
-            background: #1a202c;
-            border-color: #2d3748;
-        }
 
         .control-label {
             display: block;
@@ -173,9 +123,6 @@
             font-size: 0.95rem;
         }
 
-        .dark-theme .control-label {
-            color: #cbd5e0;
-        }
 
         .control-description {
             font-size: 0.85rem;
@@ -184,9 +131,6 @@
             line-height: 1.4;
         }
 
-        .dark-theme .control-description {
-            color: #a0aec0;
-        }
 
         .form-input, .form-select {
             width: 100%;
@@ -198,12 +142,6 @@
             transition: border-color 0.2s ease;
         }
 
-        .dark-theme .form-input,
-        .dark-theme .form-select {
-            background: #2d3748;
-            border-color: #4a5568;
-            color: #e0e0e0;
-        }
 
         .form-input:focus, .form-select:focus {
             outline: none;
@@ -225,20 +163,12 @@
             transition: all 0.2s ease;
         }
 
-        .dark-theme .farm-item {
-            background: #1a202c;
-            border-color: #2d3748;
-        }
 
         .farm-item.active {
             border-color: #667eea;
             background: #f8faff;
         }
 
-        .dark-theme .farm-item.active {
-            border-color: #4a5568;
-            background: #2a4365;
-        }
 
         .farm-name {
             font-weight: 500;
@@ -247,9 +177,6 @@
             font-size: 0.9rem;
         }
 
-        .dark-theme .farm-name {
-            color: #cbd5e0;
-        }
 
         .production-info {
             font-size: 0.8rem;
@@ -257,9 +184,6 @@
             margin-top: 0.25rem;
         }
 
-        .dark-theme .production-info {
-            color: #a0aec0;
-        }
 
         .results-panel {
             background: var(--card-bg);
@@ -269,10 +193,6 @@
             height: fit-content;
         }
 
-        .dark-theme .results-panel {
-            background: #16213e;
-            border-color: #2d3748;
-        }
 
         .results-header {
             background: var(--primary);
@@ -282,9 +202,6 @@
             font-size: 1rem;
         }
 
-        .dark-theme .results-header {
-            background: #2d3748;
-        }
 
         .results-content {
             padding: 1.5rem;
@@ -299,9 +216,6 @@
             border-bottom: 1px solid var(--border);
         }
 
-        .dark-theme .metric {
-            border-bottom-color: #2d3748;
-        }
 
         .metric:last-child {
             margin-bottom: 0;
@@ -315,9 +229,6 @@
             font-size: 0.9rem;
         }
 
-        .dark-theme .metric-label {
-            color: #cbd5e0;
-        }
 
         .metric-value {
             font-weight: 600;
@@ -325,9 +236,6 @@
             font-size: 0.9rem;
         }
 
-        .dark-theme .metric-value {
-            color: #90cdf4;
-        }
 
         .time-estimate {
             background: #f0f9ff;
@@ -338,10 +246,6 @@
             margin-top: 1rem;
         }
 
-        .dark-theme .time-estimate {
-            background: #1a365d;
-            border-color: #2c5282;
-        }
 
         .time-value {
             font-size: 1.3rem;
@@ -350,18 +254,12 @@
             margin-bottom: 0.25rem;
         }
 
-        .dark-theme .time-value {
-            color: #90cdf4;
-        }
 
         .time-label {
             color: #64748b;
             font-size: 0.85rem;
         }
 
-        .dark-theme .time-label {
-            color: #a0aec0;
-        }
 
         .empty-state {
             text-align: center;
@@ -369,9 +267,6 @@
             color: var(--text-light);
         }
 
-        .dark-theme .empty-state {
-            color: #a0aec0;
-        }
 
         .empty-state-icon {
             font-size: 2.5rem;
@@ -390,12 +285,6 @@
             color: #92400e;
         }
 
-        .dark-theme .disclaimer {
-            background: #1f2937;
-            border-color: #4b5563;
-            border-left-color: #f59e0b;
-            color: #fbbf24;
-        }
 
         @media (max-width: 768px) {
             .main-content {
@@ -423,12 +312,6 @@
                 padding: 1rem;
             }
 
-            .theme-toggle {
-                top: 0.5rem;
-                right: 0.5rem;
-                padding: 0.4rem 0.8rem;
-                font-size: 0.8rem;
-            }
         }
 
         @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- remove local `.dark-theme` overrides and custom `.theme-toggle` rules from the Protein Farm calculator page
- rely on shared CSS theme rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687408be2d3c8328a5630afdbecdfd7c