### PR TITLE
Refine dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     </header>
     <div class="toggle-container container">
         <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle">
+        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
             <div class="toggle-thumb"></div>
         </div>
     </div>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -356,7 +356,7 @@
     </header>
     <div class="toggle-container container">
         <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle">
+        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
             <div class="toggle-thumb"></div>
         </div>
     </div>

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -230,7 +230,7 @@
     </header>
     <div class="toggle-container container">
         <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle">
+        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
             <div class="toggle-thumb"></div>
         </div>
     </div>

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -336,7 +336,7 @@
     </header>
     <div class="toggle-container container">
         <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle">
+        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
             <div class="toggle-thumb"></div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,12 +1,9 @@
 function toggleDarkMode() {
-    $("body").toggleClass("dark-mode");
-    if ($("body").hasClass("dark-mode")) {
-        document.documentElement.setAttribute("data-theme", "dark");
-        localStorage.setItem("theme", "dark");
-    } else {
-        document.documentElement.setAttribute("data-theme", "light");
-        localStorage.setItem("theme", "light");
-    }
+    const currentTheme = document.documentElement.getAttribute("data-theme");
+    const newTheme = currentTheme === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", newTheme);
+    localStorage.setItem("theme", newTheme);
+    $("#themeToggle").attr("aria-pressed", newTheme === "dark");
 }
 window.toggleDarkMode = toggleDarkMode;
 
@@ -25,11 +22,9 @@ $(document).ready(function() {
     });
     $("#footer-placeholder").load(prefix + "partials/footer.html");
     const savedTheme = localStorage.getItem("theme");
-    if (savedTheme === "dark") {
-        $("body").addClass("dark-mode");
-        document.documentElement.setAttribute("data-theme", "dark");
-    } else if (savedTheme === "light") {
-        document.documentElement.setAttribute("data-theme", "light");
+    if (savedTheme === "dark" || savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", savedTheme);
+        $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
     }
     if (document.getElementById("themeToggle")) {
         $("#themeToggle").on("click", toggleDarkMode);


### PR DESCRIPTION
## Summary
- update `toggleDarkMode` to only set `data-theme` and `localStorage`
- remove unused `dark-mode` class handling
- expose dark mode toggle as an ARIA-pressed button

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68740f66de108328ba776f8c6bab66b7