### PR TITLE
Extract shared header styles

### DIFF
--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -35,39 +35,6 @@
             padding: 20px;
         }
 
-        .header {
-            text-align: center;
-            margin-bottom: 40px;
-            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-            padding: 40px;
-            border-radius: 16px;
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-            border: 1px solid var(--border);
-            color: #fff;
-        }
-
-        .header h1 {
-            font-size: 2.5rem;
-            color: #ffffff;
-            margin-bottom: 12px;
-            font-weight: 700;
-        }
-
-        .header h2 {
-            font-size: 1.5rem;
-            color: #ffffff;
-            margin-bottom: 20px;
-            font-weight: 600;
-        }
-
-        .header p {
-            font-size: 1rem;
-            color: rgba(255,255,255,0.9);
-            margin-bottom: 15px;
-            max-width: 800px;
-            margin-left: auto;
-            margin-right: auto;
-        }
 
         .disclaimer {
             background: #fef3c7;
@@ -297,17 +264,6 @@
                 padding: 16px;
             }
             
-            .header {
-                padding: 24px;
-            }
-            
-            .header h1 {
-                font-size: 2rem;
-            }
-            
-            .header h2 {
-                font-size: 1.25rem;
-            }
             
             .tech-level-1,
             .tech-level-2 {

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -37,18 +37,6 @@
             box-shadow: var(--shadow);
         }
 
-        .header {
-            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-            color: #fff;
-            padding: 32px;
-            text-align: center;
-        }
-
-        .header h1 {
-            font-size: 2.2rem;
-            font-weight: 600;
-            margin-bottom: 8px;
-        }
 
         .subtitle {
             font-size: 1.1rem;
@@ -210,10 +198,6 @@
         }
 
         @media (max-width: 768px) {
-            .header h1 {
-                font-size: 1.8rem;
-            }
-            
             .content {
                 padding: 24px;
             }

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -35,27 +35,6 @@
 
 
 
-        .header {
-            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-            color: #fff;
-            padding: 1.5rem 1rem;
-            text-align: center;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }
-
-
-        .header h1 {
-            font-size: 1.8rem;
-            font-weight: 600;
-            margin-bottom: 0.25rem;
-            color: #ffffff;
-        }
-
-        .header p {
-            font-size: 1rem;
-            opacity: 0.9;
-            color: rgba(255,255,255,0.9);
-        }
 
         .container {
             max-width: 1000px;
@@ -70,13 +49,6 @@
             margin-top: 1rem;
         }
 
-        .card {
-            background: var(--card-bg);
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-            padding: 1.5rem;
-            border: 1px solid var(--border);
-        }
 
 
         .card-header {
@@ -185,27 +157,6 @@
         }
 
 
-        .results-panel {
-            background: var(--card-bg);
-            border-radius: 8px;
-            border: 1px solid var(--border);
-            overflow: hidden;
-            height: fit-content;
-        }
-
-
-        .results-header {
-            background: var(--primary);
-            color: white;
-            padding: 1rem;
-            font-weight: 600;
-            font-size: 1rem;
-        }
-
-
-        .results-content {
-            padding: 1.5rem;
-        }
 
         .metric {
             display: flex;
@@ -292,13 +243,6 @@
                 gap: 1rem;
             }
             
-            .header h1 {
-                font-size: 1.5rem;
-            }
-            
-            .header p {
-                font-size: 0.9rem;
-            }
             
             .farm-grid {
                 grid-template-columns: 1fr;
@@ -308,20 +252,10 @@
                 padding: 0.75rem;
             }
 
-            .card {
-                padding: 1rem;
-            }
 
         }
 
         @media (max-width: 480px) {
-            .header {
-                padding: 1rem 0.5rem;
-            }
-            
-            .header h1 {
-                font-size: 1.3rem;
-            }
             
             .container {
                 padding: 0.5rem;

--- a/styles.css
+++ b/styles.css
@@ -996,3 +996,67 @@ footer {
   justify-content: center;
 }
 
+/* Shared page header styling */
+.header {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #fff;
+  text-align: center;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  border: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.header p {
+  margin: 0;
+  color: rgba(255,255,255,0.9);
+}
+
+/* Results panel used in calculators */
+.results-panel {
+  background: var(--card-bg);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  height: fit-content;
+}
+
+.results-header {
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.results-content {
+  padding: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .header h1 {
+    font-size: 1.5rem;
+  }
+
+  .header p {
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .header {
+    padding: 1rem 0.5rem;
+  }
+
+  .header h1 {
+    font-size: 1.3rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize shared `.header` and `.results-panel` CSS rules in `styles.css`
- rely on those classes from calculator and guide pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740f68460c8328a58dfb8205f356e8