### PR TITLE
Update navbar and styles; add Alliance rules page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,21 +19,11 @@
     <header class="site-header">
         <div id="nav-placeholder"></div>
     </header>
-    <div class="toggle-container container">
-        <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
-            <div class="toggle-thumb"></div>
-        </div>
-    </div>
 <main class="content">
     <div class="hero">
         <h1>Last War Resources</h1>
     </div>
-    <div class="links">
-        <a href="pages/protein-farm-calculator.html">Protein Farm Production Calculator</a>
-        <a href="pages/T10-calculator.html">Tier 10 Progress Calculator</a>
-        <a href="pages/black-market-S1.html">Season 1 Black Market Guide</a>
-    </div>
+    <p class="intro">Helpful tools and guides for the Last War: Survival community.</p>
 
 </main>
     <div id="footer-placeholder"></div>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -310,12 +310,6 @@
     <header class="site-header">
         <div id="nav-placeholder"></div>
     </header>
-    <div class="toggle-container container">
-        <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
-            <div class="toggle-thumb"></div>
-        </div>
-    </div>
     <div class="container">
         <div class="header">
             <h1>Last War: Survival</h1>

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -212,12 +212,6 @@
     <header class="site-header">
         <div id="nav-placeholder"></div>
     </header>
-    <div class="toggle-container container">
-        <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
-            <div class="toggle-thumb"></div>
-        </div>
-    </div>
     <div class="container">
         <div class="header">
             <h1>Season 1 Black Market Guide</h1>

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -268,13 +268,7 @@
     <header class="site-header">
         <div id="nav-placeholder"></div>
     </header>
-    <div class="toggle-container container">
-        <span class="toggle-label">Dark Mode</span>
-        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
-            <div class="toggle-thumb"></div>
-        </div>
-    </div>
-    
+
     <div class="header">
         <h1>Protein Farm Production Calculator</h1>
         <p>Calculate production time for Virus Research Institute upgrades</p>

--- a/pages/rules.html
+++ b/pages/rules.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+            document.documentElement.setAttribute('data-theme', savedTheme);
+        }
+    </script>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../styles.css">
+    <title>Alliance Rules</title>
+</head>
+<body>
+    <header class="site-header">
+        <div id="nav-placeholder"></div>
+    </header>
+
+    <div class="header">
+        <h1>Alliance Rules</h1>
+        <p>Guidelines to keep our community strong and organized.</p>
+    </div>
+
+    <div class="container">
+        <ol>
+            <li>Be always polite and respectful.</li>
+            <li>Be active (specially if you're F2P).</li>
+            <li>Donate to alliance tech everyday.</li>
+            <li>Meet the required minimums of the alliance.</li>
+            <li>During Zombie Invasion (golden zombies): if you can't tank a boss, don't rally it.</li>
+            <li>Be disciplined and organized: learn how to place your base in a grid, aligned with other bases.</li>
+            <li>Participate in Events: Marshall's Guard, Desert Storm, Winter Storm, Capitol War, SVS and any other relevant event introduced in the game.</li>
+        </ol>
+    </div>
+
+    <div id="footer-placeholder"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../script.js"></script>
+</body>
+</html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,8 +1,15 @@
-<nav>
+<nav class="navbar">
     <ul class="nav-menu">
         <li><a href="index.html">Home</a></li>
         <li><a href="pages/protein-farm-calculator.html">Protein Farm Calculator</a></li>
         <li><a href="pages/T10-calculator.html">Tier 10 Calculator</a></li>
         <li><a href="pages/black-market-S1.html">Black Market Guide</a></li>
+        <li><a href="pages/rules.html">Alliance Rules</a></li>
     </ul>
+    <div class="toggle-container">
+        <span class="toggle-label">Dark Mode</span>
+        <div class="theme-toggle" id="themeToggle" role="button" aria-pressed="false" tabindex="0">
+            <div class="toggle-thumb"></div>
+        </div>
+    </div>
 </nav>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ window.toggleDarkMode = toggleDarkMode;
 $(document).ready(function() {
     const isSubpage = window.location.pathname.includes('/pages/');
     const prefix = isSubpage ? '../' : '';
+    const savedTheme = localStorage.getItem("theme");
     $("#nav-placeholder").load(prefix + "partials/nav.html", function() {
         if (isSubpage) {
             $("#nav-placeholder a").each(function() {
@@ -19,16 +20,16 @@ $(document).ready(function() {
                 }
             });
         }
+        if (savedTheme === "dark" || savedTheme === "light") {
+            $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
+        }
     });
     $("#footer-placeholder").load(prefix + "partials/footer.html");
-    const savedTheme = localStorage.getItem("theme");
     if (savedTheme === "dark" || savedTheme === "light") {
         document.documentElement.setAttribute("data-theme", savedTheme);
-        $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
     }
-    if (document.getElementById("themeToggle")) {
-        $("#themeToggle").on("click", toggleDarkMode);
-    }
+
+    $(document).on("click", "#themeToggle", toggleDarkMode);
     
     // Navigation Active State for links
     $(".nav-link").click(function() {

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,9 @@ h1, h2, h3, h4, h5 {
     max-width: 1200px;
     margin: 0 auto;
     padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    width: 100%;
   }
   
   nav::-webkit-scrollbar {
@@ -127,9 +130,11 @@ h1, h2, h3, h4, h5 {
   
   .nav-menu {
     display: flex;
+    align-items: center;
     list-style: none;
     margin: 0;
     padding: 0;
+    gap: 1rem;
   }
   
   .nav-toggle {
@@ -431,8 +436,8 @@ h1, h2, h3, h4, h5 {
   .toggle-container {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
     margin: 0.5rem 0;
+    margin-left: auto;
   }
   
   .toggle-label {
@@ -923,6 +928,13 @@ h1, h2, h3, h4, h5 {
   color: #fff;
 }
 
+.intro {
+  text-align: center;
+  max-width: 600px;
+  margin: 1rem auto 2rem auto;
+  font-size: 1.1rem;
+}
+
 .links {
   display: flex;
   flex-direction: column;
@@ -993,7 +1005,7 @@ footer {
 }
 
 .site-header .nav-menu {
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 /* Shared page header styling */


### PR DESCRIPTION
## Summary
- relocate dark/light mode toggle to the navbar
- remove redundant buttons from home page and add short intro
- strip toggle markup from all calculators
- add new **Alliance Rules** page
- adjust styles for navbar and intro section
- update script to handle toggle in nav

## Testing
- `python -m py_compile \`find . -name '*.py'\`` *(fails: no Python files)*

------
https://chatgpt.com/codex/tasks/task_e_6874156233b8832895fb8778ea7b7eba