### PR TITLE
Remove progress bars from T10 Calculator

### DIFF
--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -223,21 +223,7 @@
             color: var(--text);
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 6px;
-            background: var(--border);
-            border-radius: 3px;
-            margin-top: 8px;
-            overflow: hidden;
-        }
 
-        .progress-fill {
-            height: 100%;
-            background: var(--primary);
-            border-radius: 3px;
-            transition: width 0.3s ease;
-        }
 
         .reset-button {
             background: var(--primary);
@@ -455,30 +441,18 @@
                 <div class="total-item total-gold">
                     <div class="total-label">💰 Total Gold Needed</div>
                     <div class="total-value" id="totalGoldRemainingDiv">0</div>
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="goldProgress" style="width: 0%"></div>
-                    </div>
                 </div>
                 <div class="total-item total-valor">
                     <div class="total-label">🏆 Total Valor Badges Needed</div>
                     <div class="total-value" id="totalValorRemainingDiv">0</div>
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="valorProgress" style="width: 0%"></div>
-                    </div>
                 </div>
                 <div class="total-item total-food">
                     <div class="total-label">🍖 Total Food Needed</div>
                     <div class="total-value" id="totalFoodRemainingDiv">0</div>
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="foodProgress" style="width: 0%"></div>
-                    </div>
                 </div>
                 <div class="total-item total-iron">
                     <div class="total-label">⚙️ Total Iron Needed</div>
                     <div class="total-value" id="totalIronRemainingDiv">0</div>
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="ironProgress" style="width: 0%"></div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -305,10 +305,6 @@ function initTier10Calculator() {
     const totalValorDiv = document.getElementById('totalValorRemainingDiv');
     const totalFoodDiv = document.getElementById('totalFoodRemainingDiv');
     const totalIronDiv = document.getElementById('totalIronRemainingDiv');
-    const goldProgress = document.getElementById('goldProgress');
-    const valorProgress = document.getElementById('valorProgress');
-    const foodProgress = document.getElementById('foodProgress');
-    const ironProgress = document.getElementById('ironProgress');
 
     function initializeCalculator() {
         protGold = updateDiv(advProtLvl.value, advancedProtectionGold, advProtGoldResultDiv, '💰 Gold');
@@ -355,15 +351,6 @@ function initTier10Calculator() {
         animateValue(totalFoodDiv, totalFoodNum);
         animateValue(totalIronDiv, totalIronNum);
 
-        updateProgressBar(goldProgress, maxTotalGold - totalGoldNum, maxTotalGold);
-        updateProgressBar(valorProgress, maxTotalValor - totalValorNum, maxTotalValor);
-        updateProgressBar(foodProgress, maxTotalFoodIron - totalFoodNum, maxTotalFoodIron);
-        updateProgressBar(ironProgress, maxTotalFoodIron - totalIronNum, maxTotalFoodIron);
-    }
-
-    function updateProgressBar(progressBar, current, max) {
-        const percentage = (current / max) * 100;
-        progressBar.style.width = percentage + '%';
     }
 
     function animateValue(element, targetValue) {


### PR DESCRIPTION
## Summary
- drop progress bar markup and styles from T10 calculator page
- remove progress bar logic from script.js

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759e89b1648328aacaa9c60ff12d2a