### PR TITLE
Add S1 champion duel report

### DIFF
--- a/assets/css/duel-report.css
+++ b/assets/css/duel-report.css
@@ -1,0 +1,48 @@
+.report-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.report-section {
+  margin-bottom: 2rem;
+}
+
+.report-section h2 {
+  color: var(--primary);
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--border);
+  font-weight: 600;
+}
+
+.report-section ol,
+.report-section ul {
+  margin-left: 1.5rem;
+  line-height: 1.6;
+}
+
+.player-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.player-table th,
+.player-table td {
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.player-table th {
+  background: var(--bg);
+  font-weight: 600;
+}
+
+.stats {
+  margin-top: 0.5rem;
+  color: var(--text-light);
+  font-style: italic;
+}

--- a/pages/S1-champion-duel-report.html
+++ b/pages/S1-champion-duel-report.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="../assets/js/theme.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <link rel="stylesheet" href="../assets/css/duel-report.css" />
+    <meta name="description" content="Comprehensive breakdown of the S1 Champion Duel event." />
+    <link rel="canonical" href="https://example.com/LastWar/pages/S1-champion-duel-report.html" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
+    <title>Last War: S1 Champion Duel Report</title>
+  </head>
+  <body>
+    <header class="site-header">
+      <div id="nav-placeholder"></div>
+    </header>
+    <main class="container content" role="main">
+      <div class="header">
+        <h1>S1 Champion Duel Event - Analysis Report</h1>
+        <p>Breakdown of server, alliance, and player performance.</p>
+      </div>
+      <div class="report-container">
+        <section class="report-section" id="overview">
+          <h2>Data Overview</h2>
+          <ul>
+            <li>Total Players: 128</li>
+            <li>Total Servers: 16</li>
+            <li>Total Alliances: 59</li>
+          </ul>
+        </section>
+        <section class="report-section" id="servers">
+          <h2>Strongest Servers</h2>
+          <ol>
+            <li>Server 1307: 14 players</li>
+            <li>Server 1312: 12 players</li>
+            <li>Server 1303: 12 players</li>
+            <li>Server 1304: 11 players</li>
+            <li>Server 1301: 11 players</li>
+            <li>Server 1306: 11 players</li>
+            <li>Server 1309: 10 players</li>
+            <li>Server 1305: 9 players</li>
+            <li>Server 1302: 8 players</li>
+            <li>Server 1314: 6 players</li>
+          </ol>
+          <p class="stats">
+            Average players per server: 8.0<br />
+            Most represented: Server 1307 (14 players)<br />
+            Least represented: Server 1310 (1 player)
+          </p>
+        </section>
+        <section class="report-section" id="alliances">
+          <h2>Strongest Alliances</h2>
+          <ol>
+            <li>TQAK: 8 players</li>
+            <li>KORa: 7 players</li>
+            <li>NHI: 6 players</li>
+            <li>SOF: 5 players</li>
+            <li>aREs: 5 players</li>
+            <li>XINN: 5 players</li>
+            <li>VIC: 5 players</li>
+            <li>BTW: 4 players</li>
+            <li>FEnx: 4 players</li>
+            <li>7ARQ: 4 players</li>
+          </ol>
+          <p class="stats">
+            Average players per alliance: 2.2<br />
+            Largest alliance: TQAK (8 players)
+          </p>
+        </section>
+        <section class="report-section" id="top-players">
+          <h2>Top 10 Players</h2>
+          <table class="player-table">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Alliance</th>
+                <th>Server</th>
+                <th>Killpower</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>쎄하지</td><td>TQAK</td><td>1301</td><td>38,542,458</td></tr>
+              <tr><td>N SHOHEI</td><td>PNDa</td><td>1303</td><td>37,997,244</td></tr>
+              <tr><td>TigerLữuBang</td><td>NHI</td><td>1307</td><td>37,630,500</td></tr>
+              <tr><td>Mad k</td><td>VVlp</td><td>1307</td><td>37,515,372</td></tr>
+              <tr><td>Banan a</td><td>7ARQ</td><td>1313</td><td>36,239,892</td></tr>
+              <tr><td>splinter1</td><td>XTRM</td><td>1308</td><td>35,798,304</td></tr>
+              <tr><td>Lang</td><td>HANK</td><td>1309</td><td>34,984,008</td></tr>
+              <tr><td>LAVS</td><td>KORa</td><td>1312</td><td>34,902,948</td></tr>
+              <tr><td>SING MBAU REKSO</td><td>IXON</td><td>1311</td><td>34,701,690</td></tr>
+              <tr><td>ChillWill1029</td><td>SOF</td><td>1306</td><td>34,586,478</td></tr>
+            </tbody>
+          </table>
+          <p class="stats">
+            Average Killpower: 26,565,194<br />
+            Median: 25,136,940<br />
+            Highest: 38,542,458<br />
+            Lowest: 21,580,356<br />
+            Std Dev: 4,234,664
+          </p>
+        </section>
+        <section class="report-section" id="power-tiers">
+          <h2>Power Tier Distribution</h2>
+          <ul>
+            <li>35M+ killpower: 6 players (4.7%)</li>
+            <li>30-35M killpower: 21 players (16.4%)</li>
+            <li>Below 30M killpower: 101 players (78.9%)</li>
+          </ul>
+        </section>
+        <section class="report-section" id="insights">
+          <h2>Strategic Insights</h2>
+          <ul>
+            <li>Elite tier (35M+) likely to dominate semifinals</li>
+            <li>Power gap is significant due to exponential scaling</li>
+            <li>Strong contenders (30-35M) could upset with favorable matchups</li>
+            <li>Server 1307 leads with 14 players</li>
+            <li>TQAK alliance fields 8 players</li>
+          </ul>
+        </section>
+      </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script src="../assets/js/script.js"></script>
+  </body>
+</html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -5,6 +5,7 @@
         <li><a href="pages/T10-calculator.html">Tier 10 Calculator</a></li>
         <li><a href="pages/black-market-S1.html">Black Market Guide</a></li>
         <li><a href="pages/Season2.html">Season 2 Guide</a></li>
+        <li><a href="pages/S1-champion-duel-report.html">S1 Duel Report</a></li>
         <li><a href="pages/rules.html">Our Rules</a></li>
     </ul>
     <div class="toggle-container">


### PR DESCRIPTION
## Summary
- add a detailed S1 Champion Duel analysis page
- style the report in `duel-report.css`
- link the new page from the navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c18cc468832897b10726850fd19b