### PR TITLE
Fix table of contents and navbar scrollbars

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -167,11 +167,7 @@ nav {
 
 .nav-links {
   display: flex;
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: var(--primary) var(--bg);
+  flex-wrap: wrap;
   justify-content: flex-start;
   padding: 0.5rem 1rem;
   max-width: 1200px;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -36,6 +36,9 @@ function enhanceSEO() {
 }
 
 function generateTableOfContents() {
+    const path = window.location.pathname;
+    if (path === '/' || path.endsWith('index.html')) return;
+
     const headings = document.querySelectorAll('h2, h3');
     if (headings.length < 3) return;
 


### PR DESCRIPTION
## Summary
- Skip Table of Contents generation on the home page so it no longer appears in `index.html`.
- Remove overflow settings from nav links to eliminate unwanted scrollbars and allow dropdowns to display correctly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689691c0ec308328ac65874a12f867c3