### PR TITLE
Enable PWA features, default dark theme, and lazy-load images

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -162,6 +162,17 @@ $(document).ready(function () {
 
     const isSubpage = window.location.pathname.includes('/pages/');
     const prefix = isSubpage ? '../' : '';
+
+    // Register service worker for PWA
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register(prefix + 'sw.js');
+    }
+
+    // Load analytics module
+    const analytics = document.createElement('script');
+    analytics.src = prefix + 'assets/js/analytics.js';
+    analytics.defer = true;
+    document.head.appendChild(analytics);
     const savedTheme = localStorage.getItem("theme");
     $("#nav-placeholder").load(prefix + "partials/nav.html", function () {
         if (isSubpage) {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -6,6 +6,8 @@
       var saved = localStorage.getItem('theme');
       if (saved === 'dark' || saved === 'light') {
         document.documentElement.setAttribute('data-theme', saved);
+      } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
       }
     } catch (e) {
       // Silent fail - use default theme
@@ -14,6 +16,8 @@
     var saved = StorageUtils.getItem('theme');
     if (saved === 'dark' || saved === 'light') {
       document.documentElement.setAttribute('data-theme', saved);
+    } else {
+      document.documentElement.setAttribute('data-theme', 'dark');
     }
   }
 })();
@@ -22,9 +26,9 @@
   // Get saved theme or default to light
   function getSavedTheme() {
     try {
-      return localStorage.getItem('theme') || 'light';
+      return localStorage.getItem('theme') || 'dark';
     } catch (e) {
-      return 'light';
+      return 'dark';
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="preload" href="assets/css/styles.css" as="style" />
   <link rel="preload" href="assets/js/script.js" as="script" />
+  <link rel="manifest" href="manifest.json" />
 
   <!-- Theme handling (critical) -->
   <script src="assets/js/theme.js"></script>

--- a/pages/base-building.html
+++ b/pages/base-building.html
@@ -24,7 +24,7 @@
       <h1>Base Building &amp; Development</h1>
     </div>
     <img src="../assets/img/base-hero.png" alt="Stylised survivors overlooking a base" class="responsive-img"
-      style="max-width:100%;height:auto;margin:1rem 0;border-radius:8px;" />
+      style="max-width:100%;height:auto;margin:1rem 0;border-radius:8px;" loading="lazy" />
     <p>
       Your base is your lifeline in <em>Last War: Survival</em>. Building and
       upgrading structures unlocks new features, increases production and

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -37,7 +37,7 @@
             <h2 class="card-title">Farm Configuration</h2>
           </div>
 
-          <img src="../assets/images/mip.png" alt="Immune Protein Progress" class="progress-image" />
+          <img src="../assets/images/mip.png" alt="Immune Protein Progress" class="progress-image" loading="lazy" />
 
           <div class="target-section">
             <label class="control-label">Missing Immune Protein for Next Upgrade</label>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -25,7 +25,7 @@
       <h1>Resource Management</h1>
     </div>
     <img src="../assets/img/resources.png" alt="Stylised game resources (crystals, gears, gems)" class="responsive-img"
-      style="max-width:100%;height:auto;margin:1rem 0;border-radius:8px;" />
+      style="max-width:100%;height:auto;margin:1rem 0;border-radius:8px;" loading="lazy" />
     <p>
       Resources fuel everything you do in <em>Last War: Survival</em> – from
       constructing buildings to recruiting heroes and powering your base


### PR DESCRIPTION
## Summary
- link manifest and register service worker for basic PWA support
- load analytics module using dynamic path prefix
- default to dark theme and lazy-load large images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b6a5369bc8328bc7fed5f6f20a459