### PR TITLE
fix: stabilize script load and gradient rendering

### DIFF
--- a/assets/js/visual-interactions-optimized.js
+++ b/assets/js/visual-interactions-optimized.js
@@ -52,7 +52,7 @@
             },
 
             hideInitialLoader() {
-                requestAnimationFrame(() => {
+                window.addEventListener('load', () => {
                     const overlay = document.getElementById('loadingOverlay');
                     if (overlay) {
                         overlay.classList.remove('active');

--- a/assets/js/visual-interactions.js
+++ b/assets/js/visual-interactions.js
@@ -70,10 +70,9 @@ $(document).ready(function() {
         },
         
         hideInitialLoader() {
-            // Hide initial loading after page is ready
-            setTimeout(() => {
+            window.addEventListener('load', () => {
                 this.hideLoading();
-            }, 500);
+            });
         },
         
         // Toast notification system

--- a/index.html
+++ b/index.html
@@ -33,46 +33,13 @@
         }
     </style>
     <script>
-        (function () { const t = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', t) })();
-    </script>
-    <style>
-        [data-theme="dark"] {
-            background: #0a0a0a;
-            color: #e5e5e5;
-        }
-
-        [data-theme="light"] {
-            background: #ffffff;
-            color: #1a1a1a;
-        }
-
-        .loading-overlay {
-            position: fixed;
-            inset: 0;
-            background: rgba(0, 0, 0, 0.9);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 9999;
-            opacity: 0;
-            pointer-events: none;
-            transition: opacity 0.3s;
-        }
-
-        .loading-overlay.active {
-            opacity: 1;
-            pointer-events: auto;
-        }
-    </style>
-    <script>
-        (function () { const t = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', t) })();
+        (function () {
+            const t = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', t);
+        })();
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com" media="print" onload="this.media='all'">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://fonts.googleapis.com" media="print" onload="this.media='all'" media="print"
-        onload="this.media='all'">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <title>LastWar Tools - Strategic Command Center for Last War: Survival</title>
@@ -85,11 +52,6 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="assets/css/styles.css">
     <link rel="stylesheet" href="assets/css/visual-enhancements.css">
-
-    <!-- Preconnect for performance -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" media="print" onload="this.media='all'" media="print"
-        onload="this.media='all'">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- Open Graph -->
     <meta property="og:title" content="LastWar Tools - Strategic Command Center">
@@ -331,9 +293,9 @@
     <div id="footer-placeholder"></div>
 
     <!-- Scripts -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
-    <script src="assets/js/script.js" defer defer defer></script>
-    <script src="assets/js/visual-interactions-optimized.js" defer defer defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous" defer></script>
+    <script src="assets/js/script.js" defer></script>
+    <script src="assets/js/visual-interactions-optimized.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove duplicated theme blocks and excess preconnects in `index.html`
- defer scripts and wait for full window load before hiding overlay so gradients apply consistently

## Testing
- `bash scripts/with_goal_lock.sh script-load-order-fix -- npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec9428c2483289a4569af7d9a1480