### PR TITLE
Fix double-slash URL rendering

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,11 @@
 # Last War Tools - Performance Optimization
 # Generated: 2025-08-14
 
+# Redirect multiple slashes to a single slash
+RewriteEngine On
+RewriteCond %{REQUEST_URI} ^(.*)//+(.*)$
+RewriteRule . %1/%2 [R=301,L]
+
 # Enable compression
 <IfModule mod_deflate.c>
     AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript application/json image/svg+xml

--- a/assets/js/visual-interactions.js
+++ b/assets/js/visual-interactions.js
@@ -363,7 +363,7 @@ $(document).ready(function() {
     window.navigateToTool = function(toolPath) {
         VisualEnhancements.showLoading('Initializing tool...');
         setTimeout(() => {
-            window.location.href = `pages/${toolPath}`;
+            window.location.href = `/pages/${toolPath}`;
         }, 300);
     };
     

--- a/index.html
+++ b/index.html
@@ -47,11 +47,11 @@
         content="The ultimate strategic toolkit for Last War: Survival. Interactive calculators, comprehensive guides, and real-time tools to dominate every season.">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">
 
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="assets/css/styles.css">
-    <link rel="stylesheet" href="assets/css/visual-enhancements.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/visual-enhancements.css">
 
     <!-- Open Graph -->
     <meta property="og:title" content="LastWar Tools - Strategic Command Center">
@@ -126,11 +126,11 @@
 
                     <!-- Hero Actions -->
                     <div class="hero-actions" style="margin-top: 2rem;">
-                        <a href="pages/protein-farm-calculator.html" class="btn-enhanced"
+                        <a href="/pages/protein-farm-calculator.html" class="btn-enhanced"
                             onclick="trackAction('hero_cta_calculator')">
                             🧮 Start Calculating
                         </a>
-                        <a href="pages/discord.html" class="btn-enhanced"
+                        <a href="/pages/discord.html" class="btn-enhanced"
                             style="background: linear-gradient(135deg, #5865f2, #3b47cc);"
                             onclick="trackAction('hero_cta_discord')">
                             💬 Join Community
@@ -163,7 +163,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 95%;"></div>
                         </div>
-                        <a href="pages/protein-farm-calculator.html" class="btn-enhanced">Calculate Now</a>
+                        <a href="/pages/protein-farm-calculator.html" class="btn-enhanced">Calculate Now</a>
                     </div>
 
                     <div class="tool-card gaming-border fade-in" style="animation-delay: 0.2s;"
@@ -181,7 +181,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 88%;"></div>
                         </div>
-                        <a href="pages/T10-calculator.html" class="btn-enhanced">Research Now</a>
+                        <a href="/pages/T10-calculator.html" class="btn-enhanced">Research Now</a>
                     </div>
 
                     <div class="tool-card gaming-border fade-in" style="animation-delay: 0.3s;"
@@ -199,7 +199,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 92%;"></div>
                         </div>
-                        <a href="pages/team-builder.html" class="btn-enhanced">Build Team</a>
+                        <a href="/pages/team-builder.html" class="btn-enhanced">Build Team</a>
                     </div>
                 </div>
             </div>
@@ -221,7 +221,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 100%;"></div>
                         </div>
-                        <a href="pages/season4.html" class="btn-enhanced">Read Guide</a>
+                        <a href="/pages/season4.html" class="btn-enhanced">Read Guide</a>
                     </div>
 
                     <div class="card tool-card holographic-effect fade-in" style="animation-delay: 0.2s;">
@@ -233,7 +233,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 95%;"></div>
                         </div>
-                        <a href="pages/heroes.html" class="btn-enhanced">View Tier List</a>
+                        <a href="/pages/heroes.html" class="btn-enhanced">View Tier List</a>
                     </div>
 
                     <div class="card tool-card holographic-effect fade-in" style="animation-delay: 0.3s;">
@@ -245,7 +245,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 90%;"></div>
                         </div>
-                        <a href="pages/base-building.html" class="btn-enhanced">Master Bases</a>
+                        <a href="/pages/base-building.html" class="btn-enhanced">Master Bases</a>
                     </div>
 
                     <div class="card tool-card holographic-effect fade-in" style="animation-delay: 0.4s;">
@@ -257,7 +257,7 @@
                         <div class="progress-bar">
                             <div class="progress-fill" style="width: 85%;"></div>
                         </div>
-                        <a href="pages/alliances.html" class="btn-enhanced">Join Forces</a>
+                        <a href="/pages/alliances.html" class="btn-enhanced">Join Forces</a>
                     </div>
                 </div>
             </div>
@@ -280,7 +280,7 @@
                             <span class="hero-stat-label">Live Support</span>
                         </div>
                     </div>
-                    <a href="pages/discord.html" class="btn-enhanced pulse-effect"
+                    <a href="/pages/discord.html" class="btn-enhanced pulse-effect"
                         style="background: linear-gradient(135deg, #5865f2, #3b47cc);">
                         💬 Join Discord Elite
                     </a>
@@ -294,8 +294,8 @@
 
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous" defer></script>
-    <script src="assets/js/script.js" defer></script>
-    <script src="assets/js/visual-interactions-optimized.js" defer></script>
+    <script src="/assets/js/script.js" defer></script>
+    <script src="/assets/js/visual-interactions-optimized.js" defer></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lighthouse": "lhci autorun",
     "perf-check": "node scripts/performance-monitor.js --check",
     "perf-report": "node scripts/performance-monitor.js --report",
-    "test": "npm run perf-check"
+    "test": "node tests/url-normalize.test.js && npm run perf-check"
   },
   "devDependencies": {
     "@lhci/cli": "^0.12.0",

--- a/tests/url-normalize.test.js
+++ b/tests/url-normalize.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+const resolved = new URL('/assets/css/styles.css', 'https://tooltician.com//').href;
+assert.strictEqual(resolved, 'https://tooltician.com/assets/css/styles.css');
+
+console.log('URL normalization test passed');


### PR DESCRIPTION
## Summary
- Redirect multiple slashes to a single canonical path in `.htaccess`
- Use absolute URLs for assets and internal links to avoid `//assets` resolution
- Add URL normalization test to ensure assets resolve from double-slash roots

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689faf38452883288d9517a0e1530546