### PR TITLE
feat: centralize partial paths

### DIFF
--- a/assets/js/partials.config.json
+++ b/assets/js/partials.config.json
@@ -1,0 +1,4 @@
+{
+  "nav": "/partials/nav.html",
+  "footer": "/partials/footer.html"
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -5,7 +5,12 @@
 
 (function() {
     'use strict';
-    
+    const configUrl = '/assets/js/partials.config.json';
+    const partialPaths = {
+        nav: '/partials/nav.html',
+        footer: '/partials/footer.html'
+    };
+
     let partialsLoaded = false;
 
     // Enhanced jQuery-based partial loader
@@ -15,36 +20,43 @@
 
         const savedTheme = localStorage.getItem("theme");
 
-        // Load navigation
-        $("#nav-placeholder").load("/partials/nav.html", function(response, status, xhr) {
-            if (status === "error") {
-                console.error("Failed to load navigation:", xhr.status, xhr.statusText);
-                $("#nav-placeholder").html(`
-                    <nav style="background:#1a1a2e;padding:1rem;">
-                        <a href="/index.html" style="color:#fff;text-decoration:none;font-weight:bold;">Home</a>
-                    </nav>
-                `);
-                return;
-            }
+        $.getJSON(configUrl)
+            .done(cfg => {
+                partialPaths.nav = cfg.nav || partialPaths.nav;
+                partialPaths.footer = cfg.footer || partialPaths.footer;
+            })
+            .always(() => {
+                // Load navigation
+                $("#nav-placeholder").load(partialPaths.nav, function(response, status, xhr) {
+                    if (status === "error") {
+                        console.error("Failed to load navigation:", xhr.status, xhr.statusText);
+                        $("#nav-placeholder").html(`
+                            <nav style="background:#1a1a2e;padding:1rem;">
+                                <a href="/index.html" style="color:#fff;text-decoration:none;font-weight:bold;">Home</a>
+                            </nav>
+                        `);
+                        return;
+                    }
 
-            if (savedTheme === "dark" || savedTheme === "light") {
-                $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
-            }
+                    if (savedTheme === "dark" || savedTheme === "light") {
+                        $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
+                    }
 
-            initNavigationInteractions();
-        });
+                    initNavigationInteractions();
+                });
 
-        // Load footer
-        $("#footer-placeholder").load("/partials/footer.html", function(response, status, xhr) {
-            if (status === "error") {
-                console.error("Failed to load footer:", xhr.status, xhr.statusText);
-                $("#footer-placeholder").html(`
-                    <footer style="background:#f8fafc;text-align:center;padding:1rem;border-top:1px solid #e5e7eb;">
-                        <nav><a href="/index.html">Home</a></nav>
-                    </footer>
-                `);
-            }
-        });
+                // Load footer
+                $("#footer-placeholder").load(partialPaths.footer, function(response, status, xhr) {
+                    if (status === "error") {
+                        console.error("Failed to load footer:", xhr.status, xhr.statusText);
+                        $("#footer-placeholder").html(`
+                            <footer style="background:#f8fafc;text-align:center;padding:1rem;border-top:1px solid #e5e7eb;">
+                                <nav><a href="/index.html">Home</a></nav>
+                            </footer>
+                        `);
+                    }
+                });
+            });
     }
     
     // Navigation interaction handlers


### PR DESCRIPTION
## Summary
- load navigation and footer paths from `assets/js/partials.config.json`
- keep hardcoded nav/footer fallbacks if JSON missing or unreadable
- add `partials.config.json` with default nav and footer URLs

## Testing
- `npm test`
- remove `assets/js/partials.config.json` and run fallback check to ensure default paths `/partials/nav.html` and `/partials/footer.html` were requested


------
https://chatgpt.com/codex/tasks/task_e_689fbf6b28d48328878f226f1907bb1d