### PR TITLE
feat: versioned service worker with offline fallback

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Offline - Last War Tools</title>
+  <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+</head>
+<body>
+  <main style="padding:1rem;text-align:center;">
+    <h1>You are offline</h1>
+    <p>The Last War Tools site is unavailable without a network connection.</p>
+  </main>
+</body>
+</html>

--- a/pages/offline.html
+++ b/pages/offline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Offline - Last War Tools</title>
+  <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+</head>
+<body>
+  <main style="padding:1rem;text-align:center;">
+    <h1>You are offline</h1>
+    <p>The Last War Tools site is unavailable without a network connection.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- version service worker caches and precache key assets
- add offline fallback page and serve it when network requests fail

## Testing
- `npm test`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689fc7346058832883e4bfa37d688e98