### PR TITLE
Align URLs with custom Tooltician domain

### DIFF
--- a/pages/S1-champion-duel-report.html
+++ b/pages/S1-champion-duel-report.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/duel-report.css" />
   <meta name="description" content="Comprehensive breakdown of the S1 Champion Duel event." />
-  <link rel="canonical" href="https://tooltician.com/S1-champion-duel-report.html">
+  <link rel="canonical" href="https://tooltician.com/pages/S1-champion-duel-report.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Last War: S1 Champion Duel Report</title>

--- a/pages/Season2.html
+++ b/pages/Season2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/Season2.css" />
   <meta name="description" content="Tips to master Season 2 - Polar Storm in Last War: Survival." />
-  <link rel="canonical" href="https://tooltician.com/Season2.html">
+  <link rel="canonical" href="https://tooltician.com/pages/Season2.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Last War: Survival - Season 2 Guide</title>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/T10-calculator.css" />
   <meta name="description" content="Calculate resources needed to unlock Tier 10 troops in Last War: Survival." />
-  <link rel="canonical" href="https://tooltician.com/T10-calculator.html">
+  <link rel="canonical" href="https://tooltician.com/pages/T10-calculator.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Last War: Survival - Tier 10 Progress Calculator</title>

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/black-market-S1.css" />
   <meta name="description" content="Guide to maximizing value from the Season 1 Black Market in Last War: Survival." />
-  <link rel="canonical" href="https://tooltician.com/black-market-S1.html">
+  <link rel="canonical" href="https://tooltician.com/pages/black-market-S1.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Last War: Survival - Black Market Guide</title>

--- a/pages/discord.html
+++ b/pages/discord.html
@@ -24,8 +24,8 @@
   <!-- Open Graph for Discord embeds -->
   <meta property="og:title" content="Last War: Survival Discord Community" />
   <meta property="og:description" content="Join 1000+ commanders sharing strategies, tips, and calculator results" />
-  <meta property="og:image" content="https://cortega26.github.io/LastWar/assets/images/discord-banner.png" />
-  <meta property="og:url" content="https://cortega26.github.io/LastWar/pages/discord.html" />
+  <meta property="og:image" content="https://tooltician.com/assets/images/discord-banner.png" />
+  <meta property="og:url" content="https://tooltician.com/pages/discord.html" />
 </head>
 
 <body>

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/protein-farm-calculator.css" />
   <meta name="description" content="Calculate time needed to gather immune proteins in Last War: Survival." />
-  <link rel="canonical" href="https://tooltician.com/protein-farm-calculator.html">
+  <link rel="canonical" href="https://tooltician.com/pages/protein-farm-calculator.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Protein Farm Production Calculator</title>

--- a/pages/rules.html
+++ b/pages/rules.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <link rel="stylesheet" href="../assets/css/rules.css" />
   <meta name="description" content="Alliance rules and guidelines for Last War: Survival players." />
-  <link rel="canonical" href="https://tooltician.com/rules.html">
+  <link rel="canonical" href="https://tooltician.com/pages/rules.html">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self';" />
   <title>Alliance Rules - Last War: Survival</title>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Configuration
-const baseURL = 'https://cortega26.github.io/LastWar/';
+const baseURL = 'https://tooltician.com/';
 const outputPath = 'sitemap.xml';
 
 // Priority mappings based on page type


### PR DESCRIPTION
## Summary
- fix sitemap generation script to emit Tooltician URLs
- update canonical links and Open Graph data in site pages to use tooltician.com

## Testing
- `npm test`
- `curl -I https://tooltician.com/pages/protein-farm-calculator.html`
- `curl -I https://tooltician.com/pages/Season2.html`


------
https://chatgpt.com/codex/tasks/task_e_689fcb33d12c8328b91f4363e759b996