### PR TITLE
perf: defer analytics and preload css

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <link rel="icon" type="image/png" sizes="512x512" href="/assets/images/icon-512.png">
 
     <!-- Stylesheets -->
+    <link rel="preload" href="/assets/css/styles.css" as="style">
     <link rel="stylesheet" href="/assets/css/styles.css">
     <link rel="stylesheet" href="/assets/css/visual-enhancements.css">
 
@@ -66,7 +67,7 @@
 
     <!-- Google Analytics -->
     <script defer src="https://www.googletagmanager.com/gtag/js?id=G-TV9L6C3VN7"></script>
-    <script>
+    <script defer>
         window.dataLayer = window.dataLayer || [];
         function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());


### PR DESCRIPTION
## Summary
- preload main stylesheet for faster initial render
- defer inline Google Analytics script to reduce render blocking

## Testing
- `bash scripts/run_tests.sh`
- `npx lighthouse http://localhost:8080/index.html --only-categories=performance --chrome-flags="--headless" --output=json --output-path=after.json --quiet` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_689fd236edac83289417195377e1f1a6