### PR TITLE
feat(nav): build menu from pages registry

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -10,6 +10,7 @@
         nav: '/partials/nav.html',
         footer: '/partials/footer.html'
     };
+    const pagesUrl = '/assets/pages.json';
 
     let partialsLoaded = false;
 
@@ -42,7 +43,7 @@
                         $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
                     }
 
-                    initNavigationInteractions();
+                    buildNavFromJson().always(initNavigationInteractions);
                 });
 
                 // Load footer
@@ -58,7 +59,24 @@
                 });
             });
     }
-    
+
+    function buildNavFromJson() {
+        return $.getJSON(pagesUrl)
+            .done(pages => {
+                const navMenu = $('#navMenu');
+                if (!navMenu.length) return;
+                navMenu.empty();
+                pages.forEach(page => {
+                    navMenu.append(
+                        `<li class="nav-item"><a class="nav-link" href="${page.href}">${page.title}</a></li>`
+                    );
+                });
+            })
+            .fail(() => {
+                console.warn('pages.json not found, using static navigation');
+            });
+    }
+
     // Navigation interaction handlers
     function initNavigationInteractions() {
         // Mobile navigation toggle

--- a/assets/pages.json
+++ b/assets/pages.json
@@ -1,0 +1,19 @@
+[
+  { "title": "Alliance Strategy", "href": "/pages/alliances.html" },
+  { "title": "Alliance Rules", "href": "/pages/rules.html" },
+  { "title": "Base Building", "href": "/pages/base-building.html" },
+  { "title": "Black Market Guide", "href": "/pages/black-market-S1.html" },
+  { "title": "Discord Community", "href": "/pages/discord.html" },
+  { "title": "Events Guide", "href": "/pages/events.html" },
+  { "title": "Heroes & Tier List", "href": "/pages/heroes.html" },
+  { "title": "Offline", "href": "/pages/offline.html" },
+  { "title": "Protein Farm Calculator", "href": "/pages/protein-farm-calculator.html" },
+  { "title": "Resources", "href": "/pages/resources.html" },
+  { "title": "S1 Champion Duel Report", "href": "/pages/S1-champion-duel-report.html" },
+  { "title": "Season 2 Guide", "href": "/pages/Season2.html" },
+  { "title": "Season 4 Guide", "href": "/pages/season4.html" },
+  { "title": "Seasons Overview", "href": "/pages/seasons.html" },
+  { "title": "T10 Research Calculator", "href": "/pages/T10-calculator.html" },
+  { "title": "Team Builder", "href": "/pages/team-builder.html" },
+  { "title": "Tips & Tricks", "href": "/pages/tips.html" }
+]


### PR DESCRIPTION
## Summary
- add assets/pages.json registry of site pages
- load nav links from pages.json with static fallback

## Testing
- `node - <<'NODE'...` (add/remove pages to verify nav updates)
- `bash scripts/run_tests.sh`
- `npx linkinator ./ --skip 'https?://'`


------
https://chatgpt.com/codex/tasks/task_e_689fd44f5e14832889629c1033a031bb