### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,36 @@
+name: Lighthouse
+
+on:
+  pull_request:
+
+jobs:
+  lhci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lighthouse CI
+        id: lhci
+        run: npx lhci autorun --config=lighthouserc.js
+        continue-on-error: true
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci/*.html
+
+      - name: Fail if Lighthouse assertions failed
+        if: steps.lhci.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
## Summary
- run Lighthouse CI on pull requests using existing lighthouserc.js
- publish HTML reports as artifacts and fail when thresholds are unmet

## Testing
- `npm ci`
- `npm test`
- `npx lhci autorun --config=lighthouserc.js` *(fails: Chrome not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_689fd5ab02dc8328b4512bd50727b4ba