### PR TITLE
Add client-side validation scaffold to protein calculator

### DIFF
--- a/assets/css/protein-farm-calculator.css
+++ b/assets/css/protein-farm-calculator.css
@@ -127,6 +127,12 @@
   font-weight: 500;
 }
 
+.error-message {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
 .farm-item.active .production-info {
   color: var(--primary);
 }

--- a/assets/js/validate.js
+++ b/assets/js/validate.js
@@ -1,0 +1,66 @@
+/**
+ * Simple form validation utility
+ * Validates required fields and number ranges, shows inline errors.
+ */
+(function() {
+    'use strict';
+
+    function showError(field, message) {
+        var errorEl = field.nextElementSibling;
+        if (!errorEl || !errorEl.classList.contains('error-message')) {
+            errorEl = document.createElement('div');
+            errorEl.className = 'error-message';
+            errorEl.setAttribute('aria-live', 'polite');
+            field.insertAdjacentElement('afterend', errorEl);
+        }
+        errorEl.textContent = message;
+    }
+
+    function validateField(field) {
+        var value = field.value.trim();
+        var valid = true;
+        var message = '';
+
+        if (field.hasAttribute('required') && !value) {
+            message = 'This field is required.';
+            valid = false;
+        } else if (field.type === 'number') {
+            var num = Number(value);
+            var min = field.getAttribute('min');
+            var max = field.getAttribute('max');
+            if (value === '' || isNaN(num)) {
+                message = 'Please enter a number.';
+                valid = false;
+            } else {
+                if (min !== null && num < Number(min)) {
+                    message = 'Value must be ≥ ' + min + '.';
+                    valid = false;
+                }
+                if (max !== null && num > Number(max)) {
+                    message = 'Value must be ≤ ' + max + '.';
+                    valid = false;
+                }
+            }
+        }
+
+        showError(field, message);
+        return valid;
+    }
+
+    window.attachValidation = function(form) {
+        if (!form) return;
+        form.addEventListener('submit', function(e) {
+            e.preventDefault();
+            var valid = true;
+            var fields = form.querySelectorAll('[data-validate]');
+            fields.forEach(function(field) {
+                if (!validateField(field)) {
+                    valid = false;
+                }
+            });
+            if (valid) {
+                form.dispatchEvent(new CustomEvent('formvalid'));
+            }
+        });
+    };
+})();

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -51,6 +51,7 @@
 
           <img src="../assets/images/mip.png" alt="Immune Protein Progress" class="progress-image" loading="lazy" />
 
+          <form id="proteinFarmForm" novalidate>
           <div class="target-section">
             <label class="control-label">Missing Immune Protein for Next Upgrade</label>
             <div class="control-description">
@@ -58,8 +59,9 @@
               represents how much immune protein you still need to collect for
               your next upgrade.
             </div>
-            <input type="number" id="targetAmount" class="form-input"
-              placeholder="Enter the red number from your progress bar" min="1" />
+            <input type="number" id="targetAmount" class="form-input" data-validate required
+              placeholder="Enter the red number from your progress bar" min="1" aria-describedby="targetAmountError" />
+            <div class="error-message" id="targetAmountError" aria-live="polite"></div>
           </div>
 
           <div class="farm-grid">
@@ -107,6 +109,8 @@
               <div class="production-info" id="farm5-info"></div>
             </div>
           </div>
+          <button type="submit">Calculate</button>
+          </form>
         </div>
       </div>
 
@@ -135,6 +139,12 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
     integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <script src="../assets/js/validate.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      attachValidation(document.getElementById('proteinFarmForm'));
+    });
+  </script>
   <script src="../assets/js/storage-utils.js"></script>
   <script src="../assets/js/script.js"></script>
   <script src="../assets/js/analytics.js"></script>


### PR DESCRIPTION
## Summary
- add reusable validate.js to handle required and numeric range checks
- wire Protein Farm calculator to show inline errors and prevent page reload
- style error messages for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08dacdafc8328a34921c040e1e186