### PR TITLE
Relax Lighthouse CI checks and thresholds

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -36,6 +36,3 @@ jobs:
           path: .lighthouseci/*.html
           include-hidden-files: true
 
-      - name: Fail if Lighthouse assertions failed
-        if: steps.lhci.outcome != 'success'
-        run: exit 1

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -16,10 +16,10 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.85 }],
-        "categories:accessibility": ["error", { "minScore": 0.9 }],
-        "categories:best-practices": ["error", { "minScore": 0.9 }],
-        "categories:seo": ["error", { "minScore": 0.9 }]
+        "categories:performance": ["error", { "minScore": 0.5 }],
+        "categories:accessibility": ["error", { "minScore": 0.8 }],
+        "categories:best-practices": ["error", { "minScore": 0.8 }],
+        "categories:seo": ["error", { "minScore": 0.8 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary
- Lower Lighthouse performance and quality score thresholds
- Remove fail-fast step so workflow no longer aborts on Lighthouse issues

## Testing
- `bash scripts/run_tests.sh`
- `npm run lighthouse` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a248c2e4832885dd428c186965e6