### PR TITLE
ci: remove hero optimizer from lighthouse config

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,10 +1,9 @@
 {
   "ci": {
     "collect": {
-      "url": [
-        "http://localhost:3000/",
-        "http://localhost:3000/pages/hero-optimizer.html"
-      ],
+        "url": [
+          "http://localhost:3000/"
+        ],
       "startServerCommand": "npm run serve",
       "startServerReadyPattern": "Available on",
       "startServerReadyTimeout": 20000,


### PR DESCRIPTION
## Summary
- remove non-existent hero optimizer page from Lighthouse URLs to fix CI 404

## Testing
- `npm test`
- `npm run lighthouse`


------
https://chatgpt.com/codex/tasks/task_e_68a0a887580c8328a1300cadf3e62578