### PR TITLE
docs: harden contributor guides

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ai_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ai_pr.md
@@ -8,7 +8,9 @@ What changed and why.
 
 - [ ] Tests added/updated
 - [ ] Docs updated (README/GOALS/SCOREBOARD as needed)
-- [ ] Lighthouse (key pages) within targets
+- [ ] SW cache bumped?
+- [ ] Lighthouse CI ≥ threshold?
+- [ ] A11y ≥ 90?
 - [ ] No console errors; no broken links
 - [ ] GA4 events verified (if applicable)
 - [ ] Follows `COMMIT_CONVENTION.md`

--- a/COMMIT_CONVENTION.md
+++ b/COMMIT_CONVENTION.md
@@ -3,7 +3,7 @@
 Use this format so tooling can attribute work to goals and update dashboards.
 
 ```
-[goal:GOAL_ID] <type>: <concise summary>
+[goal:GOAL_ID] <type>(area): <concise summary>
 
 Context: <1–3 sentences max>
 Tests: <what was tested or how to reproduce>
@@ -16,6 +16,15 @@ Tests: <what was tested or how to reproduce>
 
 ### Types
 feat | fix | chore | docs | refactor | test | perf | build | ci
+
+### Areas
+pages | assets | partials | pwa | seo
+
+- **pages** – HTML files and templates in `/pages`
+- **assets** – static resources like images and fonts in `/assets`
+- **partials** – shared fragments kept under `/partials`
+- **pwa** – service worker and manifest-related code
+- **seo** – metadata, structured data and search optimizations
 
 ### Rules
 - One goal per commit. If a commit touches multiple goals, split the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,16 @@ AI-first workflow with human operator.
 - Read `AGENT_WORK_CONTRACT.md` and `docs/process/AI_FIRST_DELIVERY.md`.
 - Follow `COMMIT_CONVENTION.md`.
 - Use the AI Task issue template and AI PR template.
+
+## Code Areas
+
+Categorize changes with one of these scopes:
+
+- **pages** – HTML files and page-level templates under `/pages`
+- **assets** – images, fonts and other static resources in `/assets`
+- **partials** – reusable fragments stored in `/partials`
+- **pwa** – service worker, manifest and offline assets
+- **seo** – metadata, structured data and related optimizations
+
+Check the PR template to ensure the service-worker cache is bumped and
+performance/a11y thresholds are met before submitting.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,14 +1,20 @@
-# chore(process): add AI-first docs & templates (non-destructive)
+# docs: harden contributor guides
 
 ## What changed
+- Define code areas (pages, assets, partials, pwa, seo)
+- Add checklist items for service-worker cache, Lighthouse threshold, and A11y
 
-- Add AI-first delivery addendum, prompt playbook, and sprint backlog
-- Add goals and merged scoreboard
-- Add AI Task issue template and AI PR template
-- Add process index and contributing
+## Code Areas
+- **pages** – HTML files and page-level templates under `/pages`
+- **assets** – static resources like images and fonts under `/assets`
+- **partials** – reusable fragments in `/partials`
+- **pwa** – service worker, manifest, and offline assets
+- **seo** – metadata, structured data, and search optimizations
+
+## Checklist
+- [ ] SW cache bumped?
+- [ ] Lighthouse CI ≥ threshold?
+- [ ] A11y ≥ 90?
 
 ## Validation
-
-- Inspect files under `/docs` and `/.github`
-- Create an AI Task issue and open an AI PR using templates
-- Confirm SCOREBOARD top items match current priorities
+- Open a sample PR and verify new checklist items appear


### PR DESCRIPTION
## Summary
- document code areas (pages, assets, partials, pwa, seo)
- add SW cache, Lighthouse, and A11y checks to contributor templates

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README/GOALS/SCOREBOARD as needed)
- [ ] SW cache bumped?
- [ ] Lighthouse CI ≥ threshold?
- [ ] A11y ≥ 90?
- [ ] No console errors; no broken links
- [ ] GA4 events verified (if applicable)
- [ ] Follows `COMMIT_CONVENTION.md`


------
https://chatgpt.com/codex/tasks/task_e_68a0b21aaed88328a9ca14d42796b731