### PR TITLE
Lock navigation registry with generator and link check

### DIFF
--- a/.github/workflows/verify-pages.yml
+++ b/.github/workflows/verify-pages.yml
@@ -1,0 +1,47 @@
+name: Verify pages
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check pages.json
+        run: node scripts/generate-pages-json.js
+      - name: Check internal links
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const repo = process.cwd();
+          const pagesDir = path.join(repo, 'pages');
+          const files = [path.join(repo, 'index.html'), ...fs.readdirSync(pagesDir).filter(f => f.endsWith('.html')).map(f => path.join(pagesDir, f))];
+          const missing = [];
+          for (const file of files) {
+            const html = fs.readFileSync(file, 'utf8');
+            const regex = /<a\s+[^>]*href=["']([^"'#]+)["']/g;
+            let match;
+            while ((match = regex.exec(html)) !== null) {
+              let href = match[1];
+              if (href.startsWith('http') || href.startsWith('//') || href.startsWith('mailto:')) continue;
+              if (href.startsWith('#')) continue;
+              href = href.split('#')[0].split('?')[0];
+              if (href.startsWith('/')) href = href.slice(1);
+              if (href === '') href = 'index.html';
+              const target = path.join(repo, href);
+              if (!fs.existsSync(target)) {
+                missing.push(`${file.replace(repo + path.sep, '')} -> ${match[1]}`);
+              }
+            }
+          }
+          if (missing.length) {
+            console.error('Broken links:\n' + missing.join('\n'));
+            process.exit(1);
+          }
+          NODE
+

--- a/.github/workflows/verify-pages.yml
+++ b/.github/workflows/verify-pages.yml
@@ -1,5 +1,8 @@
 name: Verify pages
 
+permissions:
+  contents: read
+
 on:
   pull_request:
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -43,7 +43,7 @@
                         $("#themeToggle").attr("aria-pressed", savedTheme === "dark");
                     }
 
-                    buildNavFromJson().always(initNavigationInteractions);
+                    buildNavFromJson().finally(initNavigationInteractions);
                 });
 
                 // Load footer
@@ -61,8 +61,12 @@
     }
 
     function buildNavFromJson() {
-        return $.getJSON(pagesUrl)
-            .done(pages => {
+        return fetch(pagesUrl)
+            .then(res => {
+                if (!res.ok) throw new Error('Failed to load pages.json');
+                return res.json();
+            })
+            .then(pages => {
                 const navMenu = $('#navMenu');
                 if (!navMenu.length) return;
                 navMenu.empty();
@@ -72,7 +76,7 @@
                     );
                 });
             })
-            .fail(() => {
+            .catch(() => {
                 console.warn('pages.json not found, using static navigation');
             });
     }

--- a/assets/pages.json
+++ b/assets/pages.json
@@ -1,19 +1,70 @@
 [
-  { "title": "Alliance Strategy", "href": "/pages/alliances.html" },
-  { "title": "Alliance Rules", "href": "/pages/rules.html" },
-  { "title": "Base Building", "href": "/pages/base-building.html" },
-  { "title": "Black Market Guide", "href": "/pages/black-market-S1.html" },
-  { "title": "Discord Community", "href": "/pages/discord.html" },
-  { "title": "Events Guide", "href": "/pages/events.html" },
-  { "title": "Heroes & Tier List", "href": "/pages/heroes.html" },
-  { "title": "Offline", "href": "/pages/offline.html" },
-  { "title": "Protein Farm Calculator", "href": "/pages/protein-farm-calculator.html" },
-  { "title": "Resources", "href": "/pages/resources.html" },
-  { "title": "S1 Champion Duel Report", "href": "/pages/S1-champion-duel-report.html" },
-  { "title": "Season 2 Guide", "href": "/pages/Season2.html" },
-  { "title": "Season 4 Guide", "href": "/pages/season4.html" },
-  { "title": "Seasons Overview", "href": "/pages/seasons.html" },
-  { "title": "T10 Research Calculator", "href": "/pages/T10-calculator.html" },
-  { "title": "Team Builder", "href": "/pages/team-builder.html" },
-  { "title": "Tips & Tricks", "href": "/pages/tips.html" }
+  {
+    "title": "Alliance Rules - Last War: Survival",
+    "href": "/pages/rules.html"
+  },
+  {
+    "title": "Alliances - Last War Tools",
+    "href": "/pages/alliances.html"
+  },
+  {
+    "title": "Base Building - Last War Tools",
+    "href": "/pages/base-building.html"
+  },
+  {
+    "title": "Events - Last War Tools",
+    "href": "/pages/events.html"
+  },
+  {
+    "title": "Heroes &amp; Tier List - Last War Tools",
+    "href": "/pages/heroes.html"
+  },
+  {
+    "title": "Join Our Discord Community - Last War Tools",
+    "href": "/pages/discord.html"
+  },
+  {
+    "title": "Last War: S1 Champion Duel Report",
+    "href": "/pages/S1-champion-duel-report.html"
+  },
+  {
+    "title": "Last War: Survival - Black Market Guide",
+    "href": "/pages/black-market-S1.html"
+  },
+  {
+    "title": "Last War: Survival - Season 2 Guide",
+    "href": "/pages/Season2.html"
+  },
+  {
+    "title": "Last War: Survival - Tier 10 Progress Calculator",
+    "href": "/pages/T10-calculator.html"
+  },
+  {
+    "title": "Last War: Survival Season 4 Guide - Evernight Isle Strategies & Best Heroes 2025",
+    "href": "/pages/season4.html"
+  },
+  {
+    "title": "Last War: Survival Team Builder - Interactive Formation Tool & Hero Calculator",
+    "href": "/pages/team-builder.html"
+  },
+  {
+    "title": "Offline - Last War Tools",
+    "href": "/pages/offline.html"
+  },
+  {
+    "title": "Protein Farm Production Calculator",
+    "href": "/pages/protein-farm-calculator.html"
+  },
+  {
+    "title": "Resources - Last War Tools",
+    "href": "/pages/resources.html"
+  },
+  {
+    "title": "Seasons - Last War Tools",
+    "href": "/pages/seasons.html"
+  },
+  {
+    "title": "Tips &amp; Tricks - Last War Tools",
+    "href": "/pages/tips.html"
+  }
 ]

--- a/scripts/generate-pages-json.js
+++ b/scripts/generate-pages-json.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  try {
+    const repoRoot = path.join(__dirname, '..');
+    const pagesDir = path.join(repoRoot, 'pages');
+    const outputPath = path.join(repoRoot, 'assets', 'pages.json');
+
+    const files = (await fs.promises.readdir(pagesDir)).filter(f => f.endsWith('.html'));
+    const pages = [];
+    for (const file of files) {
+      const fullPath = path.join(pagesDir, file);
+      const html = await fs.promises.readFile(fullPath, 'utf8');
+      const match = html.match(/<title>([^<]*)<\/title>/i);
+      if (!match) continue;
+      const title = match[1].trim();
+      pages.push({ title, href: `/pages/${file}` });
+    }
+    pages.sort((a, b) => a.title.localeCompare(b.title));
+    const json = JSON.stringify(pages, null, 2) + '\n';
+
+    let existing = null;
+    try {
+      existing = await fs.promises.readFile(outputPath, 'utf8');
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+
+    if (existing !== null && existing === json) {
+      // Up to date
+      process.exit(0);
+    }
+
+    await fs.promises.writeFile(outputPath, json);
+
+    if (existing !== null && existing !== json) {
+      console.error('assets/pages.json is out of date.');
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add generator to build `assets/pages.json` from `pages/`
- load pages list via `fetch` in script.js
- add CI to verify pages.json and validate internal links

## Testing
- `node scripts/generate-pages-json.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ba66ed388328a6247ffbf016eb67