### PR TITLE
Externalize service worker cache version

### DIFF
--- a/assets/js/sw.version.js
+++ b/assets/js/sw.version.js
@@ -1,0 +1,3 @@
+// Minimal global for service worker
+self.SW_VERSION = 'v4';
+

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,8 @@
 // Service Worker for Last War Tools PWA
-const CACHE_VERSION = 'v3';
-const STATIC_CACHE = `static-${CACHE_VERSION}`;
-const DYNAMIC_CACHE = `dynamic-${CACHE_VERSION}`;
+importScripts('/assets/js/sw.version.js');
+
+const STATIC_CACHE = `static-${self.SW_VERSION}`;
+const DYNAMIC_CACHE = `dynamic-${self.SW_VERSION}`;
 
 // Critical resources to precache
 const STATIC_ASSETS = [


### PR DESCRIPTION
## Summary
- import service worker version from a dedicated file
- reference shared version constant for static and dynamic caches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf2192f883288575124cd8b86e88