### PR TITLE
feat: precache top pages app-shell

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -17,6 +17,16 @@ const STATIC_ASSETS = [
     '/assets/images/favicon.ico'
 ];
 
+// App shell for top pages to warm cache
+const APP_SHELL = [
+    '/',
+    '/offline.html',
+    '/assets/pages.json',
+    '/pages/alliances.html',
+    '/pages/base-building.html',
+    '/pages/heroes.html'
+];
+
 // Install event - cache critical resources
 self.addEventListener('install', event => {
     console.log('[SW] Installing service worker...');
@@ -24,8 +34,11 @@ self.addEventListener('install', event => {
     event.waitUntil(
         caches.open(STATIC_CACHE)
             .then(cache => {
-                console.log('[SW] Caching static assets...');
-                return cache.addAll(STATIC_ASSETS);
+                console.log('[SW] Caching static assets and app shell...');
+                return Promise.all([
+                    cache.addAll(STATIC_ASSETS),
+                    cache.addAll(APP_SHELL)
+                ]);
             })
             .catch(err => console.error('[SW] Failed to cache static assets:', err))
     );


### PR DESCRIPTION
## Summary
- warm a tiny app-shell for key pages so they work offline
- cache static assets and app shell during service worker install

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c01e8b008328960f6aa9757ca03f