### PR TITLE
Fix broken navigation links

### DIFF
--- a/assets/pages.json
+++ b/assets/pages.json
@@ -66,5 +66,29 @@
   {
     "title": "Tips &amp; Tricks - Last War Tools",
     "href": "/pages/tips.html"
+  },
+  {
+    "title": "Season 3 - Coming Soon",
+    "href": "/pages/season3.html"
+  },
+  {
+    "title": "Season 1 - Coming Soon",
+    "href": "/pages/season1.html"
+  },
+  {
+    "title": "Pre-Season - Coming Soon",
+    "href": "/pages/pre-season.html"
+  },
+  {
+    "title": "Event Tracker - Coming Soon",
+    "href": "/pages/event-tracker.html"
+  },
+  {
+    "title": "All Calculators - Coming Soon",
+    "href": "/pages/calculators.html"
+  },
+  {
+    "title": "All Guides - Coming Soon",
+    "href": "/pages/guides.html"
   }
 ]

--- a/pages/calculators.html
+++ b/pages/calculators.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>All Calculators - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>All Calculators</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/pages/event-tracker.html
+++ b/pages/event-tracker.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>Event Tracker - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>Event Tracker</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/pages/guides.html
+++ b/pages/guides.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>All Guides - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>All Guides</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/pages/nav.html
+++ b/pages/nav.html
@@ -8,12 +8,13 @@
         <ul class="dropdown-menu">
           <li><a href="/pages/season4.html">Season 4</a></li>
           <li><a href="/pages/season3.html">Season 3</a></li>
-          <li><a href="/pages/season2.html">Season 2</a></li>
+          <li><a href="/pages/Season2.html">Season 2</a></li>
           <li><a href="/pages/season1.html">Season 1</a></li>
           <li><a href="/pages/pre-season.html">Pre-Season</a></li>
+          <li><a href="/pages/seasons.html">All Seasons Overview</a></li>
         </ul>
       </li>
-      
+
       <li class="nav-item dropdown">
         <a class="nav-link" href="#" aria-expanded="false">Calculators</a>
         <ul class="dropdown-menu">
@@ -21,9 +22,10 @@
           <li><a href="/pages/T10-calculator.html">T10 Research Calculator</a></li>
           <li><a href="/pages/team-builder.html">Team Builder</a></li>
           <li><a href="/pages/event-tracker.html">Event Tracker</a></li>
+          <li><a href="/pages/calculators.html">All Calculators</a></li>
         </ul>
       </li>
-      
+
       <li class="nav-item dropdown">
         <a class="nav-link" href="#" aria-expanded="false">Guides</a>
         <ul class="dropdown-menu">
@@ -32,6 +34,7 @@
           <li><a href="/pages/alliances.html">Alliance Strategy</a></li>
           <li><a href="/pages/resources.html">Resource Management</a></li>
           <li><a href="/pages/events.html">Events Guide</a></li>
+          <li><a href="/pages/guides.html">All Guides</a></li>
         </ul>
       </li>
       
@@ -49,8 +52,6 @@
       <button class="theme-toggle-icon" id="themeToggle" aria-label="Toggle theme" aria-pressed="false" title="Switch theme">
         <span class="theme-icon">🌙</span>
       </button>
-    </div>
-      </div>
     </div>
   </nav>
 </div>

--- a/pages/pre-season.html
+++ b/pages/pre-season.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>Pre-Season - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>Pre-Season</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/pages/season1.html
+++ b/pages/season1.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>Season 1 - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>Season 1</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/pages/season3.html
+++ b/pages/season3.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="../assets/js/theme.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <title>Season 3 - Coming Soon</title>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="site-header">
+    <div id="nav-placeholder"></div>
+  </header>
+  <main class="container content" role="main" id="main-content">
+    <h1>Season 3</h1>
+    <p>Coming soon.</p>
+  </main>
+  <footer id="footer-placeholder"></footer>
+  <script src="../assets/js/script.js"></script>
+</body>
+</html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -38,7 +38,7 @@
         <ul class="dropdown-menu">
           <li><a href="/pages/season4.html">Season 4 <span class="badge current">Current</span></a></li>
           <li><a href="/pages/season3.html">Season 3</a></li>
-          <li><a href="/pages/season2.html">Season 2</a></li>
+          <li><a href="/pages/Season2.html">Season 2</a></li>
           <li><a href="/pages/season1.html">Season 1</a></li>
           <li><a href="/pages/pre-season.html">Pre-Season</a></li>
           <li class="dropdown-divider"></li>
@@ -89,8 +89,6 @@
           <li><a href="/pages/discord.html" class="featured-link">💬 Join Discord</a></li>
           <li><a href="/pages/tips.html">Tips & Tricks</a></li>
           <li><a href="/pages/rules.html">Community Rules</a></li>
-          <li class="dropdown-divider"></li>
-          <li><a href="/pages/feedback.html">Send Feedback</a></li>
         </ul>
       </li>
 


### PR DESCRIPTION
## Summary
- restore links for past seasons and calculator pages in navigation
- add placeholder pages with "Coming soon" for missing season, calculator, and guide content
- register new pages in pages manifest for navigation

## Testing
- `node - <<'NODE' ... NODE`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d7c1b1c08328a36cb0b3b14aeaa7