### PR TITLE
Add navbar render and E2E tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@lhci/cli": "^0.12.0",
         "http-server": "^14.1.1",
         "jquery": "^3.7.1",
-        "jsdom": "^23.0.0"
+        "jsdom": "^23.0.0",
+        "playwright": "^1.48.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1817,6 +1818,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3335,6 +3351,38 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/portfinder": {
       "version": "1.0.37",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "lighthouse": "lhci autorun --config=.lighthouserc.json",
     "perf-check": "node scripts/performance-monitor.js --check",
     "perf-report": "node scripts/performance-monitor.js --report",
-    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.e2e.test.js && npm run perf-check"
+    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && npm run perf-check"
   },
   "devDependencies": {
     "@lhci/cli": "^0.12.0",
     "http-server": "^14.1.1",
     "jsdom": "^23.0.0",
-    "jquery": "^3.7.1"
+    "jquery": "^3.7.1",
+    "playwright": "^1.48.0"
   }
 }

--- a/tests/nav.playwright.test.js
+++ b/tests/nav.playwright.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const path = require('path');
+const httpServer = require('http-server');
+const { chromium } = require('playwright');
+
+(async () => {
+  const server = httpServer.createServer({ root: path.join(__dirname, '..') });
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.server.address().port;
+  const baseUrl = `http://localhost:${port}/`;
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(baseUrl);
+  await page.waitForSelector('.nav-container a');
+  const desktopHeight = await page.evaluate(() => document.querySelector('.nav-container').offsetHeight);
+  assert(desktopHeight > 0, 'desktop navbar should be visible');
+
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.waitForSelector('.nav-container a');
+  const mobileHeight = await page.evaluate(() => document.querySelector('.nav-container').offsetHeight);
+  assert(mobileHeight > 0, 'mobile navbar should be visible');
+
+  await browser.close();
+  server.close();
+  console.log('Navbar Playwright E2E test passed');
+})();

--- a/tests/nav.render.test.js
+++ b/tests/nav.render.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+const dom = new JSDOM(html, { url: 'http://localhost/', pretendToBeVisual: true });
+const { window } = dom;
+
+global.window = window;
+global.document = window.document;
+global.localStorage = window.localStorage;
+
+global.fetch = (url) => {
+  const filePath = path.join(__dirname, '..', url.replace(/^\//, ''));
+  const data = fs.readFileSync(filePath, 'utf8');
+  return Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(data),
+    json: () => Promise.resolve(JSON.parse(data))
+  });
+};
+
+const { loadPartials } = require('../assets/js/script.js');
+
+function waitForNav() {
+  return new Promise(resolve => {
+    const check = () => {
+      const nav = window.document.querySelector('.nav-container');
+      if (nav && nav.querySelectorAll('a').length) {
+        resolve(nav);
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+    check();
+  });
+}
+
+(async () => {
+  loadPartials();
+  const nav = await waitForNav();
+  const height = nav.innerHTML.trim().length;
+  assert(height > 0, 'nav container should have height > 0');
+  assert(nav.querySelectorAll('a').length > 0, 'nav should contain links');
+  console.log('Navbar render test passed');
+})();


### PR DESCRIPTION
## Summary
- add JSDOM-based render test verifying nav partial loads and contains links
- add Playwright E2E test ensuring navbar visible on desktop and mobile
- include Playwright dev dependency and test script updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec772ea4832899a9bbd688bbbc52