### PR TITLE
Ensure sitemap and robots use canonical domain

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -12,7 +12,7 @@ Allow: /assets/images/
 Allow: /assets/img/
 
 # Sitemap location - Updated with correct domain
-Sitemap: https://tooltician.com/sitemap.xml
+Sitemap: https://www.tooltician.com/sitemap.xml
 
 # Crawl-delay for politeness
 Crawl-delay: 1

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,121 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-        <loc>https://tooltician.com/</loc>
+        <loc>https://www.tooltician.com/</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/protein-farm-calculator.html</loc>
+        <loc>https://www.tooltician.com/pages/protein-farm-calculator.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/T10-calculator.html</loc>
+        <loc>https://www.tooltician.com/pages/T10-calculator.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/heroes.html</loc>
+        <loc>https://www.tooltician.com/pages/heroes.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.85</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/season4.html</loc>
+        <loc>https://www.tooltician.com/pages/season4.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.85</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/alliances.html</loc>
+        <loc>https://www.tooltician.com/pages/alliances.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/base-building.html</loc>
+        <loc>https://www.tooltician.com/pages/base-building.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/black-market-S1.html</loc>
+        <loc>https://www.tooltician.com/pages/black-market-S1.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/discord.html</loc>
+        <loc>https://www.tooltician.com/pages/discord.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/events.html</loc>
+        <loc>https://www.tooltician.com/pages/events.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/nav.html</loc>
+        <loc>https://www.tooltician.com/pages/nav.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/resources.html</loc>
+        <loc>https://www.tooltician.com/pages/resources.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/rules.html</loc>
+        <loc>https://www.tooltician.com/pages/rules.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/S1-champion-duel-report.html</loc>
+        <loc>https://www.tooltician.com/pages/S1-champion-duel-report.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/Season2.html</loc>
+        <loc>https://www.tooltician.com/pages/Season2.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/seasons.html</loc>
+        <loc>https://www.tooltician.com/pages/seasons.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/team-builder.html</loc>
+        <loc>https://www.tooltician.com/pages/team-builder.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/pages/tips.html</loc>
+        <loc>https://www.tooltician.com/pages/tips.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/partials/footer.html</loc>
+        <loc>https://www.tooltician.com/partials/footer.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tooltician.com/partials/nav.html</loc>
+        <loc>https://www.tooltician.com/partials/nav.html</loc>
         <lastmod>2025-08-14</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>


### PR DESCRIPTION
## Summary
- Canonicalize all sitemap entries to use `https://www.tooltician.com`
- Point robots.txt sitemap directive to the canonical domain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f0bc786c83289d5e00198b616295