### PR TITLE
Fix theme toggle and restore calculator scripts

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,17 +1,23 @@
 /* Accessibility - Skip Links */
 .skip-link {
     position: absolute;
-    top: -40px;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+.skip-link:focus {
     left: 0;
-    background: var(--primary);
-    color: white;
+    top: 0;
+    width: auto;
+    height: auto;
     padding: 8px;
+    background: var(--primary);
+    color: #fff;
     text-decoration: none;
     z-index: 10000;
     border-radius: 0 0 4px 0;
-}
-.skip-link:focus {
-    top: 0;
 }
 
 /* Last War Tools - Modern Frontend Styles */
@@ -162,13 +168,16 @@ code {
 
 /* ===== NAVIGATION ===== */
 .nav-container {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background: rgba(10, 14, 26, 0.95);
-  backdrop-filter: blur(20px);
-  border-bottom: 1px solid var(--border);
-  box-shadow: var(--shadow-md);
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(10, 14, 26, 0.95);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--border);
+    box-shadow: var(--shadow-md);
+    display: flex;
+    justify-content: center;
+    width: 100%;
 }
 
 .main-nav {
@@ -790,25 +799,7 @@ footer {
   justify-content: center;
 }
 
-/* Icon changes based on theme */
-[data-theme="light"] .theme-icon::before {
-  content: "üåô";
-}
-
-[data-theme="dark"] .theme-icon::before {
-  content: "‚òÄÔ∏è";
-}
-
-/* Hide default content when using pseudo-elements */
-[data-theme="light"] .theme-icon,
-[data-theme="dark"] .theme-icon {
-  font-size: 0;
-}
-
-[data-theme="light"] .theme-icon::before,
-[data-theme="dark"] .theme-icon::before {
-  font-size: 1.2rem;
-}
+  /* Icon text handled via JavaScript */
 
 /* Animation for theme transitions */
 .theme-toggle-icon:active .theme-icon {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,121 +1,99 @@
-(function () {
-  // Add storage check first
-  if (typeof StorageUtils === 'undefined') {
-    // Fallback if StorageUtils not loaded
-    try {
-      var saved = localStorage.getItem('theme');
-      if (saved === 'dark' || saved === 'light') {
-        document.documentElement.setAttribute('data-theme', saved);
-      } else {
-        document.documentElement.setAttribute('data-theme', 'dark');
-      }
-    } catch (e) {
-      // Silent fail - use default theme
-    }
-  } else {
-    var saved = StorageUtils.getItem('theme');
-    if (saved === 'dark' || saved === 'light') {
-      document.documentElement.setAttribute('data-theme', saved);
-    } else {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    }
+(function() {
+  let theme;
+  try {
+    theme = localStorage.getItem('theme');
+  } catch (e) {
+    theme = null;
   }
+  if (theme !== 'dark' && theme !== 'light') {
+    theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', theme);
 })();
 
-(function () {
-  // Get saved theme or default to dark
+(function() {
   function getSavedTheme() {
     try {
-      return localStorage.getItem('theme') || 'dark';
-    } catch (e) {
-      return 'dark';
-    }
+      const saved = localStorage.getItem('theme');
+      if (saved === 'dark' || saved === 'light') {
+        return saved;
+      }
+    } catch (e) {}
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  // Apply theme immediately to prevent flash
   function applyTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
 
-    // Update toggle state if it exists
     const toggle = document.getElementById('themeToggle');
     if (toggle) {
       toggle.setAttribute('aria-pressed', theme === 'dark');
+      const icon = toggle.querySelector('.theme-icon');
+      if (icon) {
+        icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+      }
     }
   }
 
-  // Initialize theme on page load
   const savedTheme = getSavedTheme();
   applyTheme(savedTheme);
 
-  // Theme toggle function - make it global
-  window.toggleDarkMode = function () {
-    const currentTheme = document.documentElement.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  window.toggleDarkMode = function() {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
 
-    // Apply new theme
-    applyTheme(newTheme);
-
-    // Save to localStorage
     try {
-      localStorage.setItem('theme', newTheme);
+      localStorage.setItem('theme', next);
     } catch (e) {
       console.warn('Could not save theme preference');
     }
 
-    // Track the theme change
     if (typeof gtag !== 'undefined') {
       gtag('event', 'theme_toggle', {
         event_category: 'ui_interaction',
-        event_label: newTheme,
-        new_theme: newTheme
+        event_label: next,
+        new_theme: next
       });
     }
 
-    // Smooth transition effect
     document.body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
     setTimeout(() => {
       document.body.style.transition = '';
     }, 300);
   };
 
-  // Setup theme toggle when DOM is ready
   function setupThemeToggle() {
     const toggle = document.getElementById('themeToggle');
     if (toggle) {
-      // Remove any existing listeners
       toggle.removeEventListener('click', window.toggleDarkMode);
-      
-      // Add click listener
       toggle.addEventListener('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
         window.toggleDarkMode();
       });
 
-      // Add keyboard support
       toggle.addEventListener('keydown', function(e) {
-        if (e.keyCode === 13 || e.keyCode === 32) { // Enter or Space
+        if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           window.toggleDarkMode();
         }
       });
 
-      // Set initial state
       applyTheme(savedTheme);
     }
   }
 
-  // Auto-initialize when DOM is ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', setupThemeToggle);
   } else {
     setupThemeToggle();
   }
 
-  // Also setup when navigation placeholder loads (for SPAs)
   if (typeof $ !== 'undefined') {
     $(document).ready(function() {
       $("#nav-placeholder").on("DOMNodeInserted", setupThemeToggle);
     });
   }
 })();
+

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
         gtag('js', new Date());
         gtag('config', 'G-TV9L6C3VN7');
     </script>
+    <script defer src="/assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -188,6 +188,7 @@
     </script>
   <script src="../assets/js/storage-utils.js"></script>
   <script src="../assets/js/script.js"></script>
+  <script src="../assets/js/calculators.js"></script>
   <script src="../assets/js/analytics.js"></script>
 </body>
 

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -146,6 +146,7 @@
   </script>
   <script src="../assets/js/storage-utils.js"></script>
   <script src="../assets/js/script.js"></script>
+  <script src="../assets/js/calculators.js"></script>
   <script src="../assets/js/analytics.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- fix theme toggle to respect system preference, update icon, and persist state
- hide skip link off-screen and center navigation container
- load shared calculator scripts on T10 and protein farm pages and include theme script on home

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7476cac8328a3d1f6431cd08770