### PR TITLE
Refactor protein calculator initialization and add regression test

### DIFF
--- a/assets/js/calculators.js
+++ b/assets/js/calculators.js
@@ -39,19 +39,17 @@ class LastWarCalculators {
 
     // ENHANCED PROTEIN CALCULATOR
     enhanceProteinCalculator() {
-        const calculator = this;
-
         // Add advanced features
         this.addProteinAdvancedOptions();
         this.addProteinOptimizationSuggestions();
-        this.addProteinProgressTracking();
 
-        // Enhance existing calculation with more data
-        const originalCalculate = window.initProteinCalculator;
-        if (originalCalculate) {
-            // Override with enhanced version
-            this.initEnhancedProteinCalculator();
+        // Basic global hook for backwards compatibility
+        if (!window.initProteinCalculator) {
+            window.initProteinCalculator = () => {};
         }
+
+        // Initialize the enhanced calculator directly
+        this.initEnhancedProteinCalculator();
     }
 
     initEnhancedProteinCalculator() {
@@ -64,17 +62,43 @@ class LastWarCalculators {
             26: 18720, 27: 19440, 28: 20160, 29: 20880, 30: 21600
         };
 
-        // Enhanced production calculation with bonuses
-        const enhancedRates = this.calculateEnhancedRates(productionRates);
+        // Populate farm level options
+        for (let i = 1; i <= 5; i++) {
+            const select = document.getElementById(`farm${i}`);
+            if (!select) continue;
+            for (let level = 1; level <= 30; level++) {
+                const option = document.createElement('option');
+                option.value = level;
+                option.textContent = `Level ${level}`;
+                select.appendChild(option);
+            }
+        }
 
-        // Add bonus system
-        this.addProteinBonusCalculator(enhancedRates);
+        const form = document.getElementById('proteinFarmForm');
+        const resultsDiv = document.getElementById('results-content');
+        if (!form || !resultsDiv) return;
 
-        // Add efficiency recommendations
-        this.addProteinEfficiencyAnalysis(enhancedRates);
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
 
-        // Real-time optimization suggestions
-        this.addProteinOptimizationEngine(enhancedRates);
+            const farms = this.getCurrentFarmConfiguration();
+            const targetAmount = parseInt(document.getElementById('targetAmount')?.value || 0);
+            const enhancedRates = this.calculateEnhancedRates(productionRates);
+            const totalProduction = this.calculateTotalProduction(farms, enhancedRates);
+
+            if (totalProduction <= 0 || targetAmount <= 0) {
+                resultsDiv.innerHTML = '<p>Please enter valid farm levels and target amount.</p>';
+                return;
+            }
+
+            const hours = targetAmount / totalProduction;
+            const formatted = this.formatTime(hours);
+            resultsDiv.innerHTML = `<p>Estimated Time: <strong>${formatted}</strong></p>`;
+
+            if (window.lastWarAnalytics) {
+                window.lastWarAnalytics.trackEvent('calc_run', { calculator: 'protein_farm' });
+            }
+        });
     }
 
     addProteinAdvancedOptions() {
@@ -581,6 +605,10 @@ class LastWarCalculators {
             return {};
         }
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = LastWarCalculators;
 }
 
 // Initialize enhanced calculators

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lighthouse": "lhci autorun --config=.lighthouserc.json",
     "perf-check": "node scripts/performance-monitor.js --check",
     "perf-report": "node scripts/performance-monitor.js --report",
-    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && npm run perf-check"
+    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && node tests/protein-calculator.test.js && npm run perf-check"
   },
   "devDependencies": {
     "@lhci/cli": "^0.12.0",

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -108,7 +108,7 @@
               <div class="production-info" id="farm5-info"></div>
             </div>
           </div>
-          <button type="submit">Calculate</button>
+          <button type="submit" id="calculateBtn">Calculate</button>
           </form>
         </div>
       </div>

--- a/tests/protein-calculator.test.js
+++ b/tests/protein-calculator.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(`<!DOCTYPE html><body>
+<form id="proteinFarmForm">
+  <div class="target-section"></div>
+  <input id="targetAmount" />
+  <select id="farm1"></select>
+  <select id="farm2"><option value="0">Not Built</option></select>
+  <select id="farm3"><option value="0">Not Built</option></select>
+  <select id="farm4"><option value="0">Not Built</option></select>
+  <select id="farm5"><option value="0">Not Built</option></select>
+  <div id="results-content"></div>
+  <button type="submit" id="calculateBtn"></button>
+</form>
+<select id="vipBonus"><option value="10">VIP</option></select>
+<input id="allianceTechBonus" value="0" />
+<input id="heroBonus" value="0" />
+<input id="equipmentBonus" value="0" />
+<input id="eventBonus" value="0" />
+<input id="decorationBonus" value="0" />
+</body>`, { url: 'http://localhost' });
+
+global.window = dom.window;
+global.document = dom.window.document;
+
+// Stub analytics to avoid errors
+window.lastWarAnalytics = { trackEvent: () => {} };
+
+const LastWarCalculators = require('../assets/js/calculators.js');
+
+// Prevent automatic initialization side effects
+LastWarCalculators.prototype.init = function() {};
+LastWarCalculators.prototype.addProteinAdvancedOptions = function() {};
+LastWarCalculators.prototype.addProteinOptimizationSuggestions = function() {};
+
+const calc = new LastWarCalculators();
+calc.initEnhancedProteinCalculator();
+
+document.getElementById('farm1').value = '1';
+document.getElementById('targetAmount').value = '1000';
+document.getElementById('vipBonus').value = '10';
+
+document.getElementById('proteinFarmForm').dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+const resultText = document.getElementById('results-content').textContent.trim();
+assert(resultText.includes('1h 15m'), `Expected time to include "1h 15m" but got "${resultText}"`);
+
+console.log('Protein calculator regression test passed');


### PR DESCRIPTION
## Summary
- Simplify protein calculator initialization and remove dependency on global `initProteinCalculator`
- Populate farm level options and compute production time with bonuses
- Add regression test for protein calculator and expose test via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a749f0ae308328b1b5ad78a6588237