### PR TITLE
Ensure calculators initialize after DOM ready

### DIFF
--- a/assets/js/protein-calculator.js
+++ b/assets/js/protein-calculator.js
@@ -78,11 +78,17 @@
     }
 
     if (typeof document !== 'undefined') {
-        document.addEventListener('DOMContentLoaded', () => {
+        const runInit = () => {
             if (document.getElementById('proteinFarmForm')) {
                 initProteinCalculator();
             }
-        });
+        };
+
+        if (document.readyState !== 'loading') {
+            runInit();
+        } else {
+            document.addEventListener('DOMContentLoaded', runInit);
+        }
     }
 
     if (typeof module !== 'undefined') {

--- a/assets/js/t10-calculator.js
+++ b/assets/js/t10-calculator.js
@@ -124,11 +124,17 @@
     }
 
     if (typeof document !== 'undefined') {
-        document.addEventListener('DOMContentLoaded', () => {
+        const runInit = () => {
             if (document.getElementById('adv-prot-lvl')) {
                 initT10Calculator();
             }
-        });
+        };
+
+        if (document.readyState !== 'loading') {
+            runInit();
+        } else {
+            document.addEventListener('DOMContentLoaded', runInit);
+        }
     }
 
     if (typeof module !== 'undefined') {


### PR DESCRIPTION
## Summary
- ensure protein calculator inits immediately when DOM is ready
- apply same ready-state check for T10 calculator

## Testing
- `node - <<'NODE' ...` (protein auto-init smoke test)
- `node - <<'NODE' ...` (T10 auto-init smoke test)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75293ede883288290c2238cc38a3b