### PR TITLE
Refactor calculators to ES modules

### DIFF
--- a/assets/js/calculator-utils.js
+++ b/assets/js/calculator-utils.js
@@ -1,4 +1,4 @@
-function calculateTotalProduction(farms, rates) {
+export function calculateTotalProduction(farms, rates) {
     let total = 0;
     for (const [farmNum, level] of Object.entries(farms)) {
         if (level > 0) {
@@ -8,7 +8,7 @@ function calculateTotalProduction(farms, rates) {
     return total;
 }
 
-function formatTime(hours) {
+export function formatTime(hours) {
     const days = Math.floor(hours / 24);
     const remainingHours = Math.floor(hours % 24);
     const minutes = Math.floor((hours % 1) * 60);
@@ -20,12 +20,4 @@ function formatTime(hours) {
     } else {
         return `${minutes}m`;
     }
-}
-
-if (typeof window !== 'undefined') {
-    window.calculatorUtils = { calculateTotalProduction, formatTime };
-}
-
-if (typeof module !== 'undefined') {
-    module.exports = { calculateTotalProduction, formatTime };
 }

--- a/assets/js/protein-calculator.js
+++ b/assets/js/protein-calculator.js
@@ -1,99 +1,89 @@
-(function() {
-    const utils = typeof require !== 'undefined'
-        ? require('./calculator-utils.js')
-        : window.calculatorUtils || {};
-    const { calculateTotalProduction, formatTime } = utils;
+import { calculateTotalProduction, formatTime } from './calculator-utils.js';
 
-    function getCurrentFarmConfiguration() {
-        const farms = {};
-        for (let i = 1; i <= 5; i++) {
-            const farmElement = document.getElementById(`farm${i}`);
-            farms[i] = farmElement ? parseInt(farmElement.value || 0) : 0;
-        }
-        return farms;
+function getCurrentFarmConfiguration() {
+    const farms = {};
+    for (let i = 1; i <= 5; i++) {
+        const farmElement = document.getElementById(`farm${i}`);
+        farms[i] = farmElement ? parseInt(farmElement.value || 0) : 0;
     }
+    return farms;
+}
 
-    function calculateEnhancedRates(baseRates) {
-        const vipBonus = parseInt(document.getElementById('vipBonus')?.value || 0);
-        const allianceBonus = parseInt(document.getElementById('allianceTechBonus')?.value || 0);
-        const heroBonus = parseInt(document.getElementById('heroBonus')?.value || 0);
-        const equipmentBonus = parseInt(document.getElementById('equipmentBonus')?.value || 0);
-        const eventBonus = parseInt(document.getElementById('eventBonus')?.value || 0);
-        const decorationBonus = parseInt(document.getElementById('decorationBonus')?.value || 0);
+function calculateEnhancedRates(baseRates) {
+    const vipBonus = parseInt(document.getElementById('vipBonus')?.value || 0);
+    const allianceBonus = parseInt(document.getElementById('allianceTechBonus')?.value || 0);
+    const heroBonus = parseInt(document.getElementById('heroBonus')?.value || 0);
+    const equipmentBonus = parseInt(document.getElementById('equipmentBonus')?.value || 0);
+    const eventBonus = parseInt(document.getElementById('eventBonus')?.value || 0);
+    const decorationBonus = parseInt(document.getElementById('decorationBonus')?.value || 0);
 
-        const totalBonusMultiplier = 1 + (vipBonus + allianceBonus + heroBonus + equipmentBonus + eventBonus + decorationBonus) / 100;
+    const totalBonusMultiplier =
+        1 + (vipBonus + allianceBonus + heroBonus + equipmentBonus + eventBonus + decorationBonus) / 100;
 
-        const enhancedRates = {};
-        for (const [level, rate] of Object.entries(baseRates)) {
-            enhancedRates[level] = Math.round(rate * totalBonusMultiplier);
-        }
-        return enhancedRates;
+    const enhancedRates = {};
+    for (const [level, rate] of Object.entries(baseRates)) {
+        enhancedRates[level] = Math.round(rate * totalBonusMultiplier);
     }
+    return enhancedRates;
+}
 
-    function initProteinCalculator() {
-        const productionRates = {
-            1: 720, 2: 1440, 3: 2160, 4: 2880, 5: 3600,
-            6: 4320, 7: 5040, 8: 5760, 9: 6480, 10: 7200,
-            11: 7920, 12: 8640, 13: 9360, 14: 10080, 15: 10800,
-            16: 11520, 17: 12240, 18: 12960, 19: 13680, 20: 14400,
-            21: 15120, 22: 15840, 23: 16560, 24: 17280, 25: 18000,
-            26: 18720, 27: 19440, 28: 20160, 29: 20880, 30: 21600
-        };
+export function initProteinCalculator() {
+    const productionRates = {
+        1: 720, 2: 1440, 3: 2160, 4: 2880, 5: 3600,
+        6: 4320, 7: 5040, 8: 5760, 9: 6480, 10: 7200,
+        11: 7920, 12: 8640, 13: 9360, 14: 10080, 15: 10800,
+        16: 11520, 17: 12240, 18: 12960, 19: 13680, 20: 14400,
+        21: 15120, 22: 15840, 23: 16560, 24: 17280, 25: 18000,
+        26: 18720, 27: 19440, 28: 20160, 29: 20880, 30: 21600
+    };
 
-        for (let i = 1; i <= 5; i++) {
-            const select = document.getElementById(`farm${i}`);
-            if (!select) continue;
-            for (let level = 1; level <= 30; level++) {
-                const option = document.createElement('option');
-                option.value = level;
-                option.textContent = `Level ${level}`;
-                select.appendChild(option);
-            }
-        }
-
-        const form = document.getElementById('proteinFarmForm');
-        const resultsDiv = document.getElementById('results-content');
-        if (!form || !resultsDiv || !calculateTotalProduction || !formatTime) return;
-
-        form.addEventListener('submit', (e) => {
-            e.preventDefault();
-            const farms = getCurrentFarmConfiguration();
-            const targetAmount = parseInt(document.getElementById('targetAmount')?.value || 0);
-            const enhancedRates = calculateEnhancedRates(productionRates);
-            const totalProduction = calculateTotalProduction(farms, enhancedRates);
-
-            if (totalProduction <= 0 || targetAmount <= 0) {
-                resultsDiv.innerHTML = '<p>Please enter valid farm levels and target amount.</p>';
-                return;
-            }
-
-            const hours = targetAmount / totalProduction;
-            const formatted = formatTime(hours);
-            resultsDiv.innerHTML = `<p>Estimated Time: <strong>${formatted}</strong></p>`;
-
-            if (window.lastWarAnalytics) {
-                window.lastWarAnalytics.trackEvent('calc_run', { calculator: 'protein_farm' });
-            }
-        });
-    }
-
-    if (typeof document !== 'undefined') {
-        const runInit = () => {
-            if (document.getElementById('proteinFarmForm')) {
-                initProteinCalculator();
-            }
-        };
-
-        if (document.readyState !== 'loading') {
-            runInit();
-        } else {
-            document.addEventListener('DOMContentLoaded', runInit);
+    for (let i = 1; i <= 5; i++) {
+        const select = document.getElementById(`farm${i}`);
+        if (!select) continue;
+        for (let level = 1; level <= 30; level++) {
+            const option = document.createElement('option');
+            option.value = level;
+            option.textContent = `Level ${level}`;
+            select.appendChild(option);
         }
     }
 
-    if (typeof module !== 'undefined') {
-        module.exports = { initProteinCalculator };
+    const form = document.getElementById('proteinFarmForm');
+    const resultsDiv = document.getElementById('results-content');
+    if (!form || !resultsDiv || !calculateTotalProduction || !formatTime) return;
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const farms = getCurrentFarmConfiguration();
+        const targetAmount = parseInt(document.getElementById('targetAmount')?.value || 0);
+        const enhancedRates = calculateEnhancedRates(productionRates);
+        const totalProduction = calculateTotalProduction(farms, enhancedRates);
+
+        if (totalProduction <= 0 || targetAmount <= 0) {
+            resultsDiv.innerHTML = '<p>Please enter valid farm levels and target amount.</p>';
+            return;
+        }
+
+        const hours = targetAmount / totalProduction;
+        const formatted = formatTime(hours);
+        resultsDiv.innerHTML = `<p>Estimated Time: <strong>${formatted}</strong></p>`;
+
+        if (window.lastWarAnalytics) {
+            window.lastWarAnalytics.trackEvent('calc_run', { calculator: 'protein_farm' });
+        }
+    });
+}
+
+if (typeof document !== 'undefined') {
+    const runInit = () => {
+        if (document.getElementById('proteinFarmForm')) {
+            initProteinCalculator();
+        }
+    };
+
+    if (document.readyState !== 'loading') {
+        runInit();
     } else {
-        window.initProteinCalculator = initProteinCalculator;
+        document.addEventListener('DOMContentLoaded', runInit);
     }
-})();
+}

--- a/assets/js/t10-calculator.js
+++ b/assets/js/t10-calculator.js
@@ -1,145 +1,138 @@
-(function() {
-    function initT10Calculator() {
-        const costTables = {
-            advProt: {
-                gold: [0,100,200,300,400,500,600,700,800,900,1000],
-                valor: [0,10,20,30,40,50,60,70,80,90,100],
-                food: [0,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000],
-                iron: [0,500,1000,1500,2000,2500,3000,3500,4000,4500,5000]
-            },
-            health: {
-                gold: [0,80,160,240,320,400,480,560,640,720,800],
-                valor: [0,8,16,24,32,40,48,56,64,72,80],
-                food: [0,800,1600,2400,3200,4000,4800,5600,6400,7200,8000],
-                iron: [0,400,800,1200,1600,2000,2400,2800,3200,3600,4000]
-            },
-            attack: {
-                gold: [0,90,180,270,360,450,540,630,720,810,900],
-                valor: [0,9,18,27,36,45,54,63,72,81,90],
-                food: [0,900,1800,2700,3600,4500,5400,6300,7200,8100,9000],
-                iron: [0,450,900,1350,1800,2250,2700,3150,3600,4050,4500]
-            },
-            defense: {
-                gold: [0,70,140,210,280,350,420,490,560,630,700],
-                valor: [0,7,14,21,28,35,42,49,56,63,70],
-                food: [0,700,1400,2100,2800,3500,4200,4900,5600,6300,7000],
-                iron: [0,350,700,1050,1400,1750,2100,2450,2800,3150,3500]
-            }
-        };
-
-        const selectors = {
-            advProt: document.getElementById('adv-prot-lvl'),
-            health: document.getElementById('healthLvl'),
-            attack: document.getElementById('attackLvl'),
-            defense: document.getElementById('defenseLvl')
-        };
-
-        const resultDivs = {
-            advProt: {
-                gold: document.getElementById('advProtGoldResultDiv'),
-                valor: document.getElementById('advProtValorResultDiv'),
-                food: document.getElementById('advProtFoodResultDiv'),
-                iron: document.getElementById('advProtIronResultDiv')
-            },
-            health: {
-                gold: document.getElementById('healthGoldResultDiv'),
-                valor: document.getElementById('healthValorResultDiv'),
-                food: document.getElementById('healthFoodResultDiv'),
-                iron: document.getElementById('healthIronResultDiv')
-            },
-            attack: {
-                gold: document.getElementById('attackGoldResultDiv'),
-                valor: document.getElementById('attackValorResultDiv'),
-                food: document.getElementById('attackFoodResultDiv'),
-                iron: document.getElementById('attackIronResultDiv')
-            },
-            defense: {
-                gold: document.getElementById('defenseGoldResultDiv'),
-                valor: document.getElementById('defenseValorResultDiv'),
-                food: document.getElementById('defenseFoodResultDiv'),
-                iron: document.getElementById('defenseIronResultDiv')
-            }
-        };
-
-        const totalDivs = {
-            gold: document.getElementById('totalGoldRemainingDiv'),
-            valor: document.getElementById('totalValorRemainingDiv'),
-            food: document.getElementById('totalFoodRemainingDiv'),
-            iron: document.getElementById('totalIronRemainingDiv')
-        };
-
-        const computeRemaining = (arr, level) => {
-            if (!Array.isArray(arr)) return 0;
-            if (level >= arr.length - 1) return 0;
-            let sum = 0;
-            for (let i = level + 1; i < arr.length; i++) {
-                sum += arr[i] || 0;
-            }
-            return sum;
-        };
-
-        const update = () => {
-            const totals = { gold: 0, valor: 0, food: 0, iron: 0 };
-            Object.keys(selectors).forEach(key => {
-                const level = parseInt(selectors[key]?.value || '0', 10);
-                const table = costTables[key];
-                const remaining = {
-                    gold: computeRemaining(table.gold, level),
-                    valor: computeRemaining(table.valor, level),
-                    food: computeRemaining(table.food, level),
-                    iron: computeRemaining(table.iron, level)
-                };
-
-                resultDivs[key].gold.textContent = remaining.gold.toLocaleString();
-                resultDivs[key].valor.textContent = remaining.valor.toLocaleString();
-                resultDivs[key].food.textContent = remaining.food.toLocaleString();
-                resultDivs[key].iron.textContent = remaining.iron.toLocaleString();
-
-                totals.gold += remaining.gold;
-                totals.valor += remaining.valor;
-                totals.food += remaining.food;
-                totals.iron += remaining.iron;
-            });
-
-            totalDivs.gold.textContent = totals.gold.toLocaleString();
-            totalDivs.valor.textContent = totals.valor.toLocaleString();
-            totalDivs.food.textContent = totals.food.toLocaleString();
-            totalDivs.iron.textContent = totals.iron.toLocaleString();
-        };
-
-        Object.values(selectors).forEach(sel => {
-            sel?.addEventListener('change', update);
-        });
-
-        document.querySelectorAll('.reset-button').forEach(btn => {
-            btn.addEventListener('click', () => {
-                Object.values(selectors).forEach(sel => {
-                    if (sel) sel.value = '0';
-                });
-                update();
-            });
-        });
-
-        update();
-    }
-
-    if (typeof document !== 'undefined') {
-        const runInit = () => {
-            if (document.getElementById('adv-prot-lvl')) {
-                initT10Calculator();
-            }
-        };
-
-        if (document.readyState !== 'loading') {
-            runInit();
-        } else {
-            document.addEventListener('DOMContentLoaded', runInit);
+export function initT10Calculator() {
+    const costTables = {
+        advProt: {
+            gold: [0,100,200,300,400,500,600,700,800,900,1000],
+            valor: [0,10,20,30,40,50,60,70,80,90,100],
+            food: [0,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000],
+            iron: [0,500,1000,1500,2000,2500,3000,3500,4000,4500,5000]
+        },
+        health: {
+            gold: [0,80,160,240,320,400,480,560,640,720,800],
+            valor: [0,8,16,24,32,40,48,56,64,72,80],
+            food: [0,800,1600,2400,3200,4000,4800,5600,6400,7200,8000],
+            iron: [0,400,800,1200,1600,2000,2400,2800,3200,3600,4000]
+        },
+        attack: {
+            gold: [0,90,180,270,360,450,540,630,720,810,900],
+            valor: [0,9,18,27,36,45,54,63,72,81,90],
+            food: [0,900,1800,2700,3600,4500,5400,6300,7200,8100,9000],
+            iron: [0,450,900,1350,1800,2250,2700,3150,3600,4050,4500]
+        },
+        defense: {
+            gold: [0,70,140,210,280,350,420,490,560,630,700],
+            valor: [0,7,14,21,28,35,42,49,56,63,70],
+            food: [0,700,1400,2100,2800,3500,4200,4900,5600,6300,7000],
+            iron: [0,350,700,1050,1400,1750,2100,2450,2800,3150,3500]
         }
-    }
+    };
 
-    if (typeof module !== 'undefined') {
-        module.exports = { initT10Calculator };
+    const selectors = {
+        advProt: document.getElementById('adv-prot-lvl'),
+        health: document.getElementById('healthLvl'),
+        attack: document.getElementById('attackLvl'),
+        defense: document.getElementById('defenseLvl')
+    };
+
+    const resultDivs = {
+        advProt: {
+            gold: document.getElementById('advProtGoldResultDiv'),
+            valor: document.getElementById('advProtValorResultDiv'),
+            food: document.getElementById('advProtFoodResultDiv'),
+            iron: document.getElementById('advProtIronResultDiv')
+        },
+        health: {
+            gold: document.getElementById('healthGoldResultDiv'),
+            valor: document.getElementById('healthValorResultDiv'),
+            food: document.getElementById('healthFoodResultDiv'),
+            iron: document.getElementById('healthIronResultDiv')
+        },
+        attack: {
+            gold: document.getElementById('attackGoldResultDiv'),
+            valor: document.getElementById('attackValorResultDiv'),
+            food: document.getElementById('attackFoodResultDiv'),
+            iron: document.getElementById('attackIronResultDiv')
+        },
+        defense: {
+            gold: document.getElementById('defenseGoldResultDiv'),
+            valor: document.getElementById('defenseValorResultDiv'),
+            food: document.getElementById('defenseFoodResultDiv'),
+            iron: document.getElementById('defenseIronResultDiv')
+        }
+    };
+
+    const totalDivs = {
+        gold: document.getElementById('totalGoldRemainingDiv'),
+        valor: document.getElementById('totalValorRemainingDiv'),
+        food: document.getElementById('totalFoodRemainingDiv'),
+        iron: document.getElementById('totalIronRemainingDiv')
+    };
+
+    const computeRemaining = (arr, level) => {
+        if (!Array.isArray(arr)) return 0;
+        if (level >= arr.length - 1) return 0;
+        let sum = 0;
+        for (let i = level + 1; i < arr.length; i++) {
+            sum += arr[i] || 0;
+        }
+        return sum;
+    };
+
+    const update = () => {
+        const totals = { gold: 0, valor: 0, food: 0, iron: 0 };
+        Object.keys(selectors).forEach(key => {
+            const level = parseInt(selectors[key]?.value || '0', 10);
+            const table = costTables[key];
+            const remaining = {
+                gold: computeRemaining(table.gold, level),
+                valor: computeRemaining(table.valor, level),
+                food: computeRemaining(table.food, level),
+                iron: computeRemaining(table.iron, level)
+            };
+
+            resultDivs[key].gold.textContent = remaining.gold.toLocaleString();
+            resultDivs[key].valor.textContent = remaining.valor.toLocaleString();
+            resultDivs[key].food.textContent = remaining.food.toLocaleString();
+            resultDivs[key].iron.textContent = remaining.iron.toLocaleString();
+
+            totals.gold += remaining.gold;
+            totals.valor += remaining.valor;
+            totals.food += remaining.food;
+            totals.iron += remaining.iron;
+        });
+
+        totalDivs.gold.textContent = totals.gold.toLocaleString();
+        totalDivs.valor.textContent = totals.valor.toLocaleString();
+        totalDivs.food.textContent = totals.food.toLocaleString();
+        totalDivs.iron.textContent = totals.iron.toLocaleString();
+    };
+
+    Object.values(selectors).forEach(sel => {
+        sel?.addEventListener('change', update);
+    });
+
+    document.querySelectorAll('.reset-button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            Object.values(selectors).forEach(sel => {
+                if (sel) sel.value = '0';
+            });
+            update();
+        });
+    });
+
+    update();
+}
+
+if (typeof document !== 'undefined') {
+    const runInit = () => {
+        if (document.getElementById('adv-prot-lvl')) {
+            initT10Calculator();
+        }
+    };
+
+    if (document.readyState !== 'loading') {
+        runInit();
     } else {
-        window.initT10Calculator = initT10Calculator;
+        document.addEventListener('DOMContentLoaded', runInit);
     }
-})();
+}
+

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -188,9 +188,7 @@
     </script>
   <script src="../assets/js/storage-utils.js"></script>
   <script src="../assets/js/script.js"></script>
-  <script type="module">
-    import('../assets/js/t10-calculator.js');
-  </script>
+  <script type="module" src="../assets/js/t10-calculator.js"></script>
   <script src="../assets/js/analytics.js"></script>
 </body>
 

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -146,11 +146,7 @@
   </script>
   <script src="../assets/js/storage-utils.js"></script>
   <script src="../assets/js/script.js"></script>
-  <script type="module">
-    import('../assets/js/calculator-utils.js').then(() =>
-      import('../assets/js/protein-calculator.js')
-    );
-  </script>
+  <script type="module" src="../assets/js/protein-calculator.js"></script>
   <script src="../assets/js/analytics.js"></script>
 </body>
 

--- a/tests/protein-calculator.test.js
+++ b/tests/protein-calculator.test.js
@@ -27,17 +27,26 @@ global.document = dom.window.document;
 // Stub analytics to avoid errors
 window.lastWarAnalytics = { trackEvent: () => {} };
 
-const { initProteinCalculator } = require('../assets/js/protein-calculator.js');
+async function run() {
+  const { initProteinCalculator } = await import('../assets/js/protein-calculator.js');
 
-initProteinCalculator();
+  initProteinCalculator();
 
-document.getElementById('farm1').value = '1';
-document.getElementById('targetAmount').value = '1000';
-document.getElementById('vipBonus').value = '10';
+  document.getElementById('farm1').value = '1';
+  document.getElementById('targetAmount').value = '1000';
+  document.getElementById('vipBonus').value = '10';
 
-document.getElementById('proteinFarmForm').dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+  document.getElementById('proteinFarmForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
 
-const resultText = document.getElementById('results-content').textContent.trim();
-assert(resultText.includes('1h 15m'), `Expected time to include "1h 15m" but got "${resultText}"`);
+  const resultText = document.getElementById('results-content').textContent.trim();
+  assert(
+    resultText.includes('1h 15m'),
+    `Expected time to include "1h 15m" but got "${resultText}"`
+  );
 
-console.log('Protein calculator regression test passed');
+  console.log('Protein calculator regression test passed');
+}
+
+run();

--- a/tests/t10-calculator.test.js
+++ b/tests/t10-calculator.test.js
@@ -47,38 +47,42 @@ global.document = dom.window.document;
 // stub analytics to avoid errors
 window.lastWarAnalytics = { trackEvent: () => {} };
 
-const { initT10Calculator } = require('../assets/js/t10-calculator.js');
+async function run() {
+  const { initT10Calculator } = await import('../assets/js/t10-calculator.js');
 
-initT10Calculator();
+  initT10Calculator();
 
-const setAndTrigger = (id, value) => {
-  const el = document.getElementById(id);
-  el.value = value;
-  el.dispatchEvent(new window.Event('change'));
-};
+  const setAndTrigger = (id, value) => {
+    const el = document.getElementById(id);
+    el.value = value;
+    el.dispatchEvent(new window.Event('change'));
+  };
 
-setAndTrigger('adv-prot-lvl', '5');
-setAndTrigger('healthLvl', '3');
-setAndTrigger('attackLvl', '10');
-setAndTrigger('defenseLvl', '0');
+  setAndTrigger('adv-prot-lvl', '5');
+  setAndTrigger('healthLvl', '3');
+  setAndTrigger('attackLvl', '10');
+  setAndTrigger('defenseLvl', '0');
 
-const parse = id => parseInt(document.getElementById(id).textContent.replace(/,/g, ''), 10);
+  const parse = id => parseInt(document.getElementById(id).textContent.replace(/,/g, ''), 10);
 
-assert.strictEqual(parse('advProtGoldResultDiv'), 4000);
-assert.strictEqual(parse('healthValorResultDiv'), 392);
-assert.strictEqual(parse('attackGoldResultDiv'), 0);
-assert.strictEqual(parse('defenseFoodResultDiv'), 38500);
-assert.strictEqual(parse('totalGoldRemainingDiv'), 11770);
-assert.strictEqual(parse('totalValorRemainingDiv'), 1177);
-assert.strictEqual(parse('totalFoodRemainingDiv'), 117700);
-assert.strictEqual(parse('totalIronRemainingDiv'), 58850);
+  assert.strictEqual(parse('advProtGoldResultDiv'), 4000);
+  assert.strictEqual(parse('healthValorResultDiv'), 392);
+  assert.strictEqual(parse('attackGoldResultDiv'), 0);
+  assert.strictEqual(parse('defenseFoodResultDiv'), 38500);
+  assert.strictEqual(parse('totalGoldRemainingDiv'), 11770);
+  assert.strictEqual(parse('totalValorRemainingDiv'), 1177);
+  assert.strictEqual(parse('totalFoodRemainingDiv'), 117700);
+  assert.strictEqual(parse('totalIronRemainingDiv'), 58850);
 
-// test reset behaviour
-const resetBtn = document.querySelector('.reset-button');
-resetBtn.dispatchEvent(new window.Event('click'));
+  // test reset behaviour
+  const resetBtn = document.querySelector('.reset-button');
+  resetBtn.dispatchEvent(new window.Event('click'));
 
-assert.strictEqual(document.getElementById('adv-prot-lvl').value, '0');
-assert.strictEqual(parse('advProtGoldResultDiv'), 5500);
-assert.strictEqual(parse('totalGoldRemainingDiv'), 18700);
+  assert.strictEqual(document.getElementById('adv-prot-lvl').value, '0');
+  assert.strictEqual(parse('advProtGoldResultDiv'), 5500);
+  assert.strictEqual(parse('totalGoldRemainingDiv'), 18700);
 
-console.log('T10 calculator tests passed');
+  console.log('T10 calculator tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- export `calculateTotalProduction` and `formatTime` from `calculator-utils.js`
- convert calculator scripts to ES modules and import shared utilities
- replace dynamic imports in calculator pages with module script tags

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `node tests/protein-calculator.test.js`
- `node tests/t10-calculator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7545594348328af98ff7dd34b6f3b