### PR TITLE
Refactor protein calculator for live updates

### DIFF
--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -101,13 +101,6 @@ class LastWarAnalytics {
             });
         }
 
-        // Track calculation completion
-        const calculateBtn = document.getElementById('calculateBtn');
-        if (calculateBtn) {
-            calculateBtn.addEventListener('click', () => {
-                calculator.trackCalculatorCompletion('protein_farm');
-            });
-        }
     }
 
     setupT10CalculatorEvents() {
@@ -454,21 +447,6 @@ function trackDiscordClick() {
 
 // Auto-track calculator usage
 $(document).ready(function () {
-    // Track protein farm calculator usage
-    $('#calculateBtn').on('click', function () {
-        const farmLevels = [];
-        for (let i = 1; i <= 5; i++) {
-            const level = parseInt($(`#farm${i}`).val()) || 0;
-            if (level > 0) farmLevels.push(level);
-        }
-        const targetAmount = parseInt($('#targetAmount').val()) || 0;
-
-        trackCalculatorRun('protein_farm', {
-            active_farms: farmLevels.length,
-            target_amount: targetAmount > 100000 ? 'high' : targetAmount > 10000 ? 'medium' : 'low'
-        });
-    });
-
     // Track T10 calculator usage
     $('.tech-node select').on('change', function () {
         const techType = $(this).attr('id');

--- a/assets/js/protein-calculator.js
+++ b/assets/js/protein-calculator.js
@@ -52,8 +52,7 @@ export function initProteinCalculator() {
     const resultsDiv = document.getElementById('results-content');
     if (!form || !resultsDiv || !calculateTotalProduction || !formatTime) return;
 
-    form.addEventListener('submit', (e) => {
-        e.preventDefault();
+    function updateResults() {
         const farms = getCurrentFarmConfiguration();
         const targetAmount = parseInt(document.getElementById('targetAmount')?.value || 0);
         const enhancedRates = calculateEnhancedRates(productionRates);
@@ -71,7 +70,23 @@ export function initProteinCalculator() {
         if (window.lastWarAnalytics) {
             window.lastWarAnalytics.trackEvent('calc_run', { calculator: 'protein_farm' });
         }
+    }
+
+    const targetInput = document.getElementById('targetAmount');
+    if (targetInput) targetInput.addEventListener('input', updateResults);
+
+    for (let i = 1; i <= 5; i++) {
+        const select = document.getElementById(`farm${i}`);
+        if (select) select.addEventListener('change', updateResults);
+    }
+
+    const bonusFields = ['vipBonus', 'allianceTechBonus', 'heroBonus', 'equipmentBonus', 'eventBonus', 'decorationBonus'];
+    bonusFields.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('input', updateResults);
     });
+
+    updateResults();
 }
 
 if (typeof document !== 'undefined') {

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -108,7 +108,6 @@
               <div class="production-info" id="farm5-info"></div>
             </div>
           </div>
-          <button type="submit" id="calculateBtn">Calculate</button>
           </form>
         </div>
       </div>

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -43,21 +43,6 @@ function trackDiscordClick() {
 
 // Auto-track calculator usage
 $(document).ready(function () {
-    // Track protein farm calculator usage
-    $('#calculateBtn').on('click', function () {
-        const farmLevels = [];
-        for (let i = 1; i <= 5; i++) {
-            const level = parseInt($(`#farm${i}`).val()) || 0;
-            if (level > 0) farmLevels.push(level);
-        }
-        const targetAmount = parseInt($('#targetAmount').val()) || 0;
-
-        trackCalculatorRun('protein_farm', {
-            active_farms: farmLevels.length,
-            target_amount: targetAmount > 100000 ? 'high' : targetAmount > 10000 ? 'medium' : 'low'
-        });
-    });
-
     // Track T10 calculator usage
     $('.tech-node select').on('change', function () {
         const techType = $(this).attr('id');

--- a/tests/protein-calculator.test.js
+++ b/tests/protein-calculator.test.js
@@ -11,7 +11,6 @@ const dom = new JSDOM(`<!DOCTYPE html><body>
   <select id="farm4"><option value="0">Not Built</option></select>
   <select id="farm5"><option value="0">Not Built</option></select>
   <div id="results-content"></div>
-  <button type="submit" id="calculateBtn"></button>
 </form>
 <select id="vipBonus"><option value="10">VIP</option></select>
 <input id="allianceTechBonus" value="0" />
@@ -32,13 +31,17 @@ async function run() {
 
   initProteinCalculator();
 
-  document.getElementById('farm1').value = '1';
-  document.getElementById('targetAmount').value = '1000';
-  document.getElementById('vipBonus').value = '10';
+  const farm1 = document.getElementById('farm1');
+  farm1.value = '1';
+  farm1.dispatchEvent(new window.Event('change', { bubbles: true }));
 
-  document.getElementById('proteinFarmForm').dispatchEvent(
-    new window.Event('submit', { bubbles: true, cancelable: true })
-  );
+  const vipBonus = document.getElementById('vipBonus');
+  vipBonus.value = '10';
+  vipBonus.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+  const target = document.getElementById('targetAmount');
+  target.value = '1000';
+  target.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   const resultText = document.getElementById('results-content').textContent.trim();
   assert(


### PR DESCRIPTION
## Summary
- compute protein farm results with new `updateResults` function and bind to form inputs
- drop manual calculate button and associated analytics hooks
- adjust regression test to simulate input changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75c951b9883288bb2e6d90073efa6