### PR TITLE
fix: reference shared Boost III arrays for defense

### DIFF
--- a/assets/js/t10-calculator.js
+++ b/assets/js/t10-calculator.js
@@ -60,9 +60,9 @@ export function initT10Calculator() {
         },
         defense: {
             gold: guardianOutfitterGold,
-            valor: [...guardianOutfitterValor.slice(0, -1), guardianOutfitterValor[guardianOutfitterValor.length - 1] + 1],
-            bread: [...guardianOutfitterBread.slice(0, -1), guardianOutfitterBread[guardianOutfitterBread.length - 1] + 1],
-            iron: [...guardianOutfitterBread.slice(0, -1), guardianOutfitterBread[guardianOutfitterBread.length - 1] + 1]
+            valor: guardianOutfitterValor,
+            bread: guardianOutfitterBread,
+            iron: guardianOutfitterBread
         }
     };
 

--- a/tests/t10-calculator.test.js
+++ b/tests/t10-calculator.test.js
@@ -60,9 +60,9 @@ async function run() {
   const initialValor = parse('totalValorRemainingDiv');
 
   assert.strictEqual(initialGold, 7936800000);
-  assert.strictEqual(initialValor, 67841);
-  assert.strictEqual(initialBread, 2654800001);
-  assert.strictEqual(initialIron, 2654800001);
+  assert.strictEqual(initialValor, 67840);
+  assert.strictEqual(initialBread, 2654800000);
+  assert.strictEqual(initialIron, 2654800000);
 
   const setAndTrigger = (id, value) => {
     const el = document.getElementById(id);


### PR DESCRIPTION
## Summary
- remove spread override in defense cost tables and reuse shared Boost III arrays
- adjust t10 calculator test totals for new defense costs

## Testing
- `npm test`
- `node tests/t10-calculator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a76828e06c832892d75caf9d1e835f