### PR TITLE
Use theme variable for loading overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -43,6 +43,7 @@
   --bg-card: #1e2330;
   --bg-hover: #2a2f3f;
   --nav-bg: rgba(10, 14, 26, 0.95);
+  --overlay-bg: rgba(10, 14, 26, 0.9);
   
   /* Text Colors */
   --text-primary: #ffffff;
@@ -82,6 +83,7 @@
   --bg-card: #ffffff;
   --bg-hover: #f8fafc;
   --nav-bg: rgba(255, 255, 255, 0.95);
+  --overlay-bg: rgba(255, 255, 255, 0.9);
   --text-primary: #1a202c;
   --text-secondary: #4a5568;
   --text-muted: #718096;

--- a/assets/css/visual-enhancements.css
+++ b/assets/css/visual-enhancements.css
@@ -314,7 +314,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(10, 14, 26, 0.9);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -14,23 +14,6 @@
             color: #1a1a1a;
         }
 
-        .loading-overlay {
-            position: fixed;
-            inset: 0;
-            background: rgba(0, 0, 0, 0.9);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 9999;
-            opacity: 0;
-            pointer-events: none;
-            transition: opacity 0.3s;
-        }
-
-        .loading-overlay.active {
-            opacity: 1;
-            pointer-events: auto;
-        }
     </style>
     <script>
         (function () {


### PR DESCRIPTION
## Summary
- use new `--overlay-bg` theme variable for loading overlay
- define `--overlay-bg` for dark and light themes
- remove inline loading overlay CSS from `index.html`

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a77719c208832895ccf016bb1c216d