### PR TITLE
Remove inline theme styles from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,6 @@
 
 <head>
     <meta charset="UTF-8">
-    <style>
-        [data-theme="dark"] {
-            background: #0a0a0a;
-            color: #e5e5e5;
-        }
-
-        [data-theme="light"] {
-            background: #ffffff;
-            color: #1a1a1a;
-        }
-
-    </style>
     <script>
         (function () {
             const t = localStorage.getItem('theme') || 'dark';


### PR DESCRIPTION
## Summary
- drop hard-coded dark/light colors from index.html
- ensure data-theme is still set early and rely on stylesheet for theme colors

## Testing
- `node - <<'NODE'...` (verify data-theme attribute)
- `npm test` *(fails: missing Playwright system deps)*

------
https://chatgpt.com/codex/tasks/task_e_68a7789627888328b340c139d71f94df