### PR TITLE
feat: inline theme setup on all pages

### DIFF
--- a/pages/S1-champion-duel-report.html
+++ b/pages/S1-champion-duel-report.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/Season2.html
+++ b/pages/Season2.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/T10-calculator.html
+++ b/pages/T10-calculator.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/alliances.html
+++ b/pages/alliances.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -24,6 +25,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/base-building.html
+++ b/pages/base-building.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -24,6 +25,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/black-market-S1.html
+++ b/pages/black-market-S1.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/calculators.html
+++ b/pages/calculators.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>All Calculators - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/discord.html
+++ b/pages/discord.html
@@ -1,9 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
@@ -26,6 +27,7 @@
   <meta property="og:description" content="Join 1000+ commanders sharing strategies, tips, and calculator results" />
   <meta property="og:image" content="https://tooltician.com/assets/images/discord-banner.png" />
   <meta property="og:url" content="https://tooltician.com/pages/discord.html" />
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/event-tracker.html
+++ b/pages/event-tracker.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>Event Tracker - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/events.html
+++ b/pages/events.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -24,6 +25,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/guides.html
+++ b/pages/guides.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>All Guides - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/heroes.html
+++ b/pages/heroes.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -24,6 +25,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/offline.html
+++ b/pages/offline.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Offline - Last War Tools</title>
   <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <main style="padding:1rem;text-align:center;">

--- a/pages/pre-season.html
+++ b/pages/pre-season.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>Pre-Season - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -25,6 +26,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/rules.html
+++ b/pages/rules.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -27,6 +28,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/season1.html
+++ b/pages/season1.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>Season 1 - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/season3.html
+++ b/pages/season3.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
   <title>Season 3 - Coming Soon</title>
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/season4.html
+++ b/pages/season4.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
     <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="../assets/js/theme.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -37,6 +38,7 @@
         gtag('config', 'G-TV9L6C3VN7');
     </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/seasons.html
+++ b/pages/seasons.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -25,6 +26,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/team-builder.html
+++ b/pages/team-builder.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
     <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="../assets/js/theme.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -31,6 +32,7 @@
         gtag('config', 'G-TV9L6C3VN7');
     </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>

--- a/pages/tips.html
+++ b/pages/tips.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){const theme = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', theme);})();</script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="../assets/js/theme.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -24,6 +25,7 @@
     gtag('config', 'G-TV9L6C3VN7');
   </script>
 
+  <script defer src="../assets/js/theme.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- inline critical theme loader before CSS on every page
- default to `data-theme="dark"` to avoid FOUC
- defer full theme logic for consistent toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a779f0238c8328b06edf088a1c0809