### PR TITLE
Refactor color variables across calculators

### DIFF
--- a/assets/css/T10-calculator.css
+++ b/assets/css/T10-calculator.css
@@ -29,7 +29,7 @@
 }
 
 .tech-node {
-  background: var(--card-bg);
+  background: var(--bg-card);
   padding: 24px;
   border-radius: 12px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
@@ -53,7 +53,7 @@
   display: block;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   margin-bottom: 16px;
   text-align: center;
 }
@@ -68,10 +68,10 @@ select {
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 0.95rem;
-  background: var(--card-bg);
+  background: var(--bg-card);
   cursor: pointer;
   transition: all 0.2s ease;
-  color: var(--text);
+  color: var(--text-primary);
 }
 
 select:focus {
@@ -120,7 +120,7 @@ select:focus {
 }
 
 .totals-section {
-  background: var(--card-bg);
+  background: var(--bg-card);
   padding: 32px;
   border-radius: 16px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
@@ -175,7 +175,7 @@ select:focus {
 .total-value {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--text-primary);
 }
 
 .reset-button {

--- a/assets/css/black-market-S1.css
+++ b/assets/css/black-market-S1.css
@@ -1,8 +1,8 @@
 .container {
   max-width: 900px;
   margin: 0 auto;
-  background: var(--card-bg);
-  box-shadow: var(--shadow);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-md);
 }
 
 .subtitle {
@@ -28,7 +28,7 @@
 }
 
 .section h3 {
-  color: var(--text);
+  color: var(--text-primary);
   font-size: 1.2rem;
   margin: 0 0 0 0;
   font-weight: 600;
@@ -50,14 +50,14 @@
 }
 
 .item-card {
-  background: var(--card-bg);
+  background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 20px;
 }
 
 .item-card h4 {
-  color: var(--text);
+  color: var(--text-primary);
   font-size: 1.1rem;
   margin-bottom: 12px;
   font-weight: 600;
@@ -65,7 +65,7 @@
 
 .item-card p {
   font-size: 14px;
-  color: var(--text-light);
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 
@@ -88,7 +88,7 @@
 }
 
 .priority-item {
-  background: var(--card-bg);
+  background: var(--bg-card);
   margin: 12px 0;
   padding: 16px 20px;
   border-radius: 6px;
@@ -112,7 +112,7 @@
 }
 
 .priority-item h4 {
-  color: var(--text);
+  color: var(--text-primary);
   font-size: 1.1rem;
   margin-bottom: 8px;
   font-weight: 600;
@@ -120,7 +120,7 @@
 
 .priority-item p {
   font-size: 14px;
-  color: var(--text-light);
+  color: var(--text-secondary);
   margin-bottom: 4px;
 }
 
@@ -153,7 +153,7 @@ li {
 }
 
 strong {
-  color: var(--text);
+  color: var(--text-primary);
   font-weight: 600;
 }
 

--- a/assets/css/duel-report.css
+++ b/assets/css/duel-report.css
@@ -43,6 +43,6 @@
 
 .stats {
   margin-top: 0.5rem;
-  color: var(--text-light);
+  color: var(--text-secondary);
   font-style: italic;
 }

--- a/assets/css/protein-farm-calculator.css
+++ b/assets/css/protein-farm-calculator.css
@@ -13,10 +13,10 @@
 }
 
 .input-section, .results-section {
-  background: var(--card-bg);
+  background: var(--bg-card);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-md);
   border: 1px solid var(--border);
 }
 
@@ -27,7 +27,7 @@
 .card-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -49,14 +49,14 @@
 .control-label {
   display: block;
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   margin-bottom: 0.5rem;
   font-size: 1rem;
 }
 
 .control-description {
   font-size: 0.875rem;
-  color: var(--text-light);
+  color: var(--text-secondary);
   margin-bottom: 1rem;
   line-height: 1.5;
 }
@@ -68,7 +68,7 @@
   border-radius: 8px;
   font-size: 1rem;
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-primary);
   transition: border-color 0.2s ease;
 }
 
@@ -94,12 +94,12 @@
 
 .farm-item.active {
   border-color: var(--primary);
-  background: var(--card-bg);
+  background: var(--bg-card);
 }
 
 .farm-name {
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   margin-bottom: 0.5rem;
   font-size: 0.95rem;
 }
@@ -110,7 +110,7 @@
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-primary);
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
   cursor: pointer;
@@ -123,7 +123,7 @@
 
 .production-info {
   font-size: 0.8rem;
-  color: var(--text-light);
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
@@ -144,7 +144,7 @@
 .results-header {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   margin-bottom: 1.5rem;
   padding-bottom: 0.5rem;
   border-bottom: 2px solid var(--border);
@@ -153,7 +153,7 @@
 .empty-state {
   text-align: center;
   padding: 2rem;
-  color: var(--text-light);
+  color: var(--text-secondary);
 }
 
 .empty-state-icon {
@@ -183,7 +183,7 @@
 
 .result-label {
   font-weight: 600;
-  color: var(--text);
+  color: var(--text-primary);
   font-size: 0.9rem;
 }
 

--- a/assets/css/rules.css
+++ b/assets/css/rules.css
@@ -23,7 +23,7 @@
 }
 
 .rule-content {
-  color: var(--text);
+  color: var(--text-primary);
   line-height: 1.6;
   margin-left: 1.5rem;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -56,7 +56,12 @@
   --border-light: #374151;
   --glow: 0 0 20px rgba(255, 107, 53, 0.3);
   --glow-secondary: 0 0 15px rgba(100, 255, 218, 0.2);
-  
+
+  /* Feedback */
+  --warning-bg: rgba(253, 230, 138, 0.1);
+  --warning-border: rgba(253, 230, 138, 0.4);
+  --warning-text: #fde68a;
+
   /* Shadows */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
@@ -91,6 +96,9 @@
   --border: #e2e8f0;
   --border-light: #edf2f7;
   --glow: 0 0 20px rgba(255, 107, 53, 0.1);
+  --warning-bg: #fff3cd;
+  --warning-border: #ffeaa7;
+  --warning-text: #856404;
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.15);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- align specialized tool styles with global `--bg-card` and updated text tokens
- define shared warning color variables in `styles.css`
- replace deprecated `--shadow` with `--shadow-md`

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bcd6e3c8328b2fe8a498dd00c3f