### PR TITLE
Streamline navigation and rename calculators to tools

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -780,7 +780,7 @@ footer {
 
 /* Brand styling updates */
 .nav-brand .brand-link {
-  cursor: default;
+  cursor: pointer;
   text-decoration: none;
 }
 

--- a/assets/pages.json
+++ b/assets/pages.json
@@ -1,7 +1,7 @@
 [
   {
-    "title": "All Calculators - Coming Soon",
-    "href": "/pages/calculators.html"
+    "title": "All Tools - Coming Soon",
+    "href": "/pages/tools.html"
   },
   {
     "title": "All Guides - Coming Soon",
@@ -84,7 +84,7 @@
     "href": "/pages/season3.html"
   },
   {
-    "title": "Seasons - Last War Tools",
+    "title": "Season Guides - Last War Tools",
     "href": "/pages/seasons.html"
   },
   {

--- a/pages/nav.html
+++ b/pages/nav.html
@@ -4,25 +4,13 @@
       <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
       
       <li class="nav-item dropdown">
-        <a class="nav-link" href="#" aria-expanded="false">Seasons</a>
-        <ul class="dropdown-menu">
-          <li><a href="/pages/season4.html">Season 4</a></li>
-          <li><a href="/pages/season3.html">Season 3</a></li>
-          <li><a href="/pages/Season2.html">Season 2</a></li>
-          <li><a href="/pages/season1.html">Season 1</a></li>
-          <li><a href="/pages/pre-season.html">Pre-Season</a></li>
-          <li><a href="/pages/seasons.html">All Seasons Overview</a></li>
-        </ul>
-      </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link" href="#" aria-expanded="false">Calculators</a>
+        <a class="nav-link" href="#" aria-expanded="false">Tools</a>
         <ul class="dropdown-menu">
           <li><a href="/pages/protein-farm-calculator.html">Protein Farm Calculator</a></li>
           <li><a href="/pages/T10-calculator.html">T10 Research Calculator</a></li>
           <li><a href="/pages/team-builder.html">Team Builder</a></li>
           <li><a href="/pages/event-tracker.html">Event Tracker</a></li>
-          <li><a href="/pages/calculators.html">All Calculators</a></li>
+          <li><a href="/pages/tools.html">All Tools</a></li>
         </ul>
       </li>
 
@@ -34,6 +22,15 @@
           <li><a href="/pages/alliances.html">Alliance Strategy</a></li>
           <li><a href="/pages/resources.html">Resource Management</a></li>
           <li><a href="/pages/events.html">Events Guide</a></li>
+          <li><a href="/pages/tips.html">Tips & Tricks</a></li>
+          <li class="dropdown-divider"></li>
+          <li><a href="/pages/season4.html">Season 4</a></li>
+          <li><a href="/pages/season3.html">Season 3</a></li>
+          <li><a href="/pages/Season2.html">Season 2</a></li>
+          <li><a href="/pages/season1.html">Season 1</a></li>
+          <li><a href="/pages/pre-season.html">Pre-Season</a></li>
+          <li><a href="/pages/seasons.html">All Season Guides</a></li>
+          <li class="dropdown-divider"></li>
           <li><a href="/pages/guides.html">All Guides</a></li>
         </ul>
       </li>
@@ -42,7 +39,6 @@
         <a class="nav-link" href="#" aria-expanded="false">Community</a>
         <ul class="dropdown-menu">
           <li><a href="/pages/discord.html">Discord</a></li>
-          <li><a href="/pages/tips.html">Tips & Tricks</a></li>
           <li><a href="/pages/rules.html">Community Rules</a></li>
         </ul>
       </li>

--- a/pages/tools.html
+++ b/pages/tools.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/styles.css" />
-  <title>All Calculators - Coming Soon</title>
+  <title>All Tools - Coming Soon</title>
   <script defer src="../assets/js/theme.js"></script>
 </head>
 <body>
@@ -18,7 +18,7 @@
     <div id="nav-placeholder"></div>
   </header>
   <main class="container content" role="main" id="main-content">
-    <h1>All Calculators</h1>
+    <h1>All Tools</h1>
     <p>Coming soon.</p>
   </main>
   <footer id="footer-placeholder"></footer>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,11 +1,11 @@
 <div class="nav-container">
   <nav class="main-nav" aria-label="Primary">
-    <!-- Logo/Brand (no home link) -->
+    <!-- Logo/Brand (links home) -->
     <div class="nav-brand">
-      <span class="brand-link">
+      <a href="/" class="brand-link">
         <!-- <span class="brand-icon">⚔️</span> -->
         <!-- <span class="brand-text">LastWar<span class="brand-accent">Tools</span></span> -->
-      </span>
+      </a>
     </div>
 
     <!-- Search Integration -->
@@ -31,25 +31,8 @@
 
       <li class="nav-item dropdown" role="none">
         <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false" role="menuitem">
-          <span class="nav-icon">📅</span>
-          <span class="nav-text">Seasons</span>
-          <span class="dropdown-arrow">▼</span>
-        </a>
-        <ul class="dropdown-menu" role="menu">
-          <li role="none"><a href="/pages/season4.html" role="menuitem">Season 4 <span class="badge current">Current</span></a></li>
-          <li role="none"><a href="/pages/season3.html" role="menuitem">Season 3</a></li>
-          <li role="none"><a href="/pages/Season2.html" role="menuitem">Season 2</a></li>
-          <li role="none"><a href="/pages/season1.html" role="menuitem">Season 1</a></li>
-          <li role="none"><a href="/pages/pre-season.html" role="menuitem">Pre-Season</a></li>
-          <li class="dropdown-divider" role="separator"></li>
-          <li role="none"><a href="/pages/seasons.html" role="menuitem">All Seasons Overview</a></li>
-        </ul>
-      </li>
-
-      <li class="nav-item dropdown" role="none">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false" role="menuitem">
-          <span class="nav-icon">🧮</span>
-          <span class="nav-text">Calculators</span>
+          <span class="nav-icon">🛠️</span>
+          <span class="nav-text">Tools</span>
           <span class="dropdown-arrow">▼</span>
         </a>
         <ul class="dropdown-menu" role="menu">
@@ -58,7 +41,7 @@
           <li role="none"><a href="/pages/team-builder.html" role="menuitem">Team Builder</a></li>
           <li role="none"><a href="/pages/event-tracker.html" role="menuitem">Event Tracker</a></li>
           <li class="dropdown-divider" role="separator"></li>
-          <li role="none"><a href="/pages/calculators.html" role="menuitem">All Calculators</a></li>
+          <li role="none"><a href="/pages/tools.html" role="menuitem">All Tools</a></li>
         </ul>
       </li>
 
@@ -74,6 +57,14 @@
           <li role="none"><a href="/pages/alliances.html" role="menuitem">Alliance Strategy</a></li>
           <li role="none"><a href="/pages/resources.html" role="menuitem">Resource Management</a></li>
           <li role="none"><a href="/pages/events.html" role="menuitem">Events Guide</a></li>
+          <li role="none"><a href="/pages/tips.html" role="menuitem">Tips &amp; Tricks</a></li>
+          <li class="dropdown-divider" role="separator"></li>
+          <li role="none"><a href="/pages/season4.html" role="menuitem">Season 4 <span class="badge current">Current</span></a></li>
+          <li role="none"><a href="/pages/season3.html" role="menuitem">Season 3</a></li>
+          <li role="none"><a href="/pages/Season2.html" role="menuitem">Season 2</a></li>
+          <li role="none"><a href="/pages/season1.html" role="menuitem">Season 1</a></li>
+          <li role="none"><a href="/pages/pre-season.html" role="menuitem">Pre-Season</a></li>
+          <li role="none"><a href="/pages/seasons.html" role="menuitem">All Season Guides</a></li>
           <li class="dropdown-divider" role="separator"></li>
           <li role="none"><a href="/pages/guides.html" role="menuitem">All Guides</a></li>
         </ul>
@@ -87,7 +78,6 @@
         </a>
         <ul class="dropdown-menu" role="menu">
           <li role="none"><a href="/pages/discord.html" class="featured-link" role="menuitem">💬 Join Discord</a></li>
-          <li role="none"><a href="/pages/tips.html" role="menuitem">Tips & Tricks</a></li>
           <li role="none"><a href="/pages/rules.html" role="menuitem">Community Rules</a></li>
         </ul>
       </li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -79,7 +79,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://tooltician.com/pages/calculators.html</loc>
+    <loc>https://tooltician.com/pages/tools.html</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>

--- a/tests/nav.e2e.test.js
+++ b/tests/nav.e2e.test.js
@@ -15,23 +15,23 @@ global.$ = $;
 const { initNavigationInteractions } = require('../assets/js/script.js');
 initNavigationInteractions();
 
-const seasons = $('.nav-item.dropdown').first();
+const tools = $('.nav-item.dropdown').first();
 
 // Hover test
-seasons.trigger('mouseenter');
-assert.strictEqual(seasons.find('> .nav-link').attr('aria-expanded'), 'true');
-seasons.trigger('mouseleave');
-assert.strictEqual(seasons.find('> .nav-link').attr('aria-expanded'), 'false');
+tools.trigger('mouseenter');
+assert.strictEqual(tools.find('> .nav-link').attr('aria-expanded'), 'true');
+tools.trigger('mouseleave');
+assert.strictEqual(tools.find('> .nav-link').attr('aria-expanded'), 'false');
 
 // Mobile click test
 window.innerWidth = 500;
-const link = seasons.find('> .nav-link');
+const link = tools.find('> .nav-link');
 link.trigger('click');
-assert(seasons.hasClass('active') && seasons.find('.dropdown-menu').hasClass('show'));
+assert(tools.hasClass('active') && tools.find('.dropdown-menu').hasClass('show'));
 
 // Keyboard navigation
 window.innerWidth = 1200;
-seasons.find('> .nav-link').trigger($.Event('keydown', { key: 'ArrowDown' }));
-assert(document.activeElement.textContent.trim().startsWith('Season 4'));
+tools.find('> .nav-link').trigger($.Event('keydown', { key: 'ArrowDown' }));
+assert(document.activeElement.textContent.trim().startsWith('Protein Farm'));
 
 console.log('Navbar E2E test passed');

--- a/tests/nav.playwright.test.js
+++ b/tests/nav.playwright.test.js
@@ -12,12 +12,12 @@ const { chromium } = require('playwright');
   const browser = await chromium.launch();
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   await page.goto(baseUrl);
-  await page.waitForSelector('.nav-container a');
+  await page.waitForSelector('.nav-container a', { state: 'attached' });
   const desktopHeight = await page.evaluate(() => document.querySelector('.nav-container').offsetHeight);
   assert(desktopHeight > 0, 'desktop navbar should be visible');
 
   await page.setViewportSize({ width: 375, height: 667 });
-  await page.waitForSelector('.nav-container a');
+  await page.waitForSelector('.nav-container a', { state: 'attached' });
   const mobileHeight = await page.evaluate(() => document.querySelector('.nav-container').offsetHeight);
   assert(mobileHeight > 0, 'mobile navbar should be visible');
 


### PR DESCRIPTION
## Summary
- rename top-level Calculators section to Tools and add All Tools hub
- move seasons under Guides as Season Guides and shift Tips & Tricks from Community
- make brand mark link to home and trim Community to Discord + rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78c40ebf88328b322bb300961d1b7