### PR TITLE
Remove redundant menu roles from navigation

### DIFF
--- a/partials/nav.html
+++ b/partials/nav.html
@@ -21,64 +21,64 @@
     </button>
 
     <!-- Navigation Menu -->
-    <ul class="nav-menu" id="navMenu" role="menubar">
-      <li class="nav-item" role="none">
-        <a class="nav-link" href="/" aria-current="page" role="menuitem">
+    <ul class="nav-menu" id="navMenu">
+      <li class="nav-item">
+        <a class="nav-link" href="/" aria-current="page">
           <span class="nav-icon">🏠</span>
           <span class="nav-text">Home</span>
         </a>
       </li>
 
-      <li class="nav-item dropdown" role="none">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false" role="menuitem">
+      <li class="nav-item dropdown">
+        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
           <span class="nav-icon">🛠️</span>
           <span class="nav-text">Tools</span>
           <span class="dropdown-arrow">▼</span>
         </a>
-        <ul class="dropdown-menu" role="menu">
-          <li role="none"><a href="/pages/protein-farm-calculator.html" role="menuitem">Protein Farm Calculator</a></li>
-          <li role="none"><a href="/pages/T10-calculator.html" role="menuitem">T10 Research Calculator</a></li>
-          <li role="none"><a href="/pages/team-builder.html" role="menuitem">Team Builder</a></li>
-          <li role="none"><a href="/pages/event-tracker.html" role="menuitem">Event Tracker</a></li>
+        <ul class="dropdown-menu">
+          <li><a href="/pages/protein-farm-calculator.html">Protein Farm Calculator</a></li>
+          <li><a href="/pages/T10-calculator.html">T10 Research Calculator</a></li>
+          <li><a href="/pages/team-builder.html">Team Builder</a></li>
+          <li><a href="/pages/event-tracker.html">Event Tracker</a></li>
           <li class="dropdown-divider" role="separator"></li>
-          <li role="none"><a href="/pages/tools.html" role="menuitem">All Tools</a></li>
+          <li><a href="/pages/tools.html">All Tools</a></li>
         </ul>
       </li>
 
-      <li class="nav-item dropdown" role="none">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false" role="menuitem">
+      <li class="nav-item dropdown">
+        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
           <span class="nav-icon">📚</span>
           <span class="nav-text">Guides</span>
           <span class="dropdown-arrow">▼</span>
         </a>
-        <ul class="dropdown-menu" role="menu">
-          <li role="none"><a href="/pages/heroes.html" role="menuitem">Heroes &amp; Tier List</a></li>
-          <li role="none"><a href="/pages/base-building.html" role="menuitem">Base Building</a></li>
-          <li role="none"><a href="/pages/alliances.html" role="menuitem">Alliance Strategy</a></li>
-          <li role="none"><a href="/pages/resources.html" role="menuitem">Resource Management</a></li>
-          <li role="none"><a href="/pages/events.html" role="menuitem">Events Guide</a></li>
-          <li role="none"><a href="/pages/tips.html" role="menuitem">Tips &amp; Tricks</a></li>
+        <ul class="dropdown-menu">
+          <li><a href="/pages/heroes.html">Heroes &amp; Tier List</a></li>
+          <li><a href="/pages/base-building.html">Base Building</a></li>
+          <li><a href="/pages/alliances.html">Alliance Strategy</a></li>
+          <li><a href="/pages/resources.html">Resource Management</a></li>
+          <li><a href="/pages/events.html">Events Guide</a></li>
+          <li><a href="/pages/tips.html">Tips &amp; Tricks</a></li>
           <li class="dropdown-divider" role="separator"></li>
-          <li role="none"><a href="/pages/season4.html" role="menuitem">Season 4 <span class="badge current">Current</span></a></li>
-          <li role="none"><a href="/pages/season3.html" role="menuitem">Season 3</a></li>
-          <li role="none"><a href="/pages/Season2.html" role="menuitem">Season 2</a></li>
-          <li role="none"><a href="/pages/season1.html" role="menuitem">Season 1</a></li>
-          <li role="none"><a href="/pages/pre-season.html" role="menuitem">Pre-Season</a></li>
-          <li role="none"><a href="/pages/seasons.html" role="menuitem">All Season Guides</a></li>
+          <li><a href="/pages/season4.html">Season 4 <span class="badge current">Current</span></a></li>
+          <li><a href="/pages/season3.html">Season 3</a></li>
+          <li><a href="/pages/Season2.html">Season 2</a></li>
+          <li><a href="/pages/season1.html">Season 1</a></li>
+          <li><a href="/pages/pre-season.html">Pre-Season</a></li>
+          <li><a href="/pages/seasons.html">All Season Guides</a></li>
           <li class="dropdown-divider" role="separator"></li>
-          <li role="none"><a href="/pages/guides.html" role="menuitem">All Guides</a></li>
+          <li><a href="/pages/guides.html">All Guides</a></li>
         </ul>
       </li>
 
-      <li class="nav-item dropdown" role="none">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false" role="menuitem">
+      <li class="nav-item dropdown">
+        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
           <span class="nav-icon">💡</span>
           <span class="nav-text">Community</span>
           <span class="dropdown-arrow">▼</span>
         </a>
-        <ul class="dropdown-menu" role="menu">
-          <li role="none"><a href="/pages/discord.html" class="featured-link" role="menuitem">💬 Join Discord</a></li>
-          <li role="none"><a href="/pages/rules.html" role="menuitem">Community Rules</a></li>
+        <ul class="dropdown-menu">
+          <li><a href="/pages/discord.html" class="featured-link">💬 Join Discord</a></li>
+          <li><a href="/pages/rules.html">Community Rules</a></li>
         </ul>
       </li>
 


### PR DESCRIPTION
## Summary
- rely on native nav semantics by dropping menu-related roles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a795bc03a883288825f0066bc629aa