### PR TITLE
fix: add visible focus outlines for search and calculators

### DIFF
--- a/assets/css/T10-calculator.css
+++ b/assets/css/T10-calculator.css
@@ -75,7 +75,8 @@ select {
 }
 
 select:focus {
-  outline: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }

--- a/assets/css/protein-farm-calculator.css
+++ b/assets/css/protein-farm-calculator.css
@@ -73,7 +73,8 @@
 }
 
 .form-input:focus {
-  outline: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(184, 18, 18, 0.1);
 }
@@ -117,7 +118,8 @@
 }
 
 .form-select:focus {
-  outline: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
   border-color: var(--primary);
 }
 

--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -24,7 +24,8 @@
     border-radius: 25px;
     color: #ffffff;
     font-size: 14px;
-    outline: none;
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
     transition: all 0.3s ease;
     backdrop-filter: blur(10px);
 }

--- a/assets/css/visual-enhancements.css
+++ b/assets/css/visual-enhancements.css
@@ -272,7 +272,8 @@
   border-radius: 50px;
   color: var(--text-primary);
   font-size: 1rem;
-  outline: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
   transition: all 0.3s ease;
   backdrop-filter: blur(20px);
 }


### PR DESCRIPTION
## Summary
- ensure search input and enhanced search use visible outlines for focus
- restore focus outlines on T10 and protein farm calculator inputs

## Testing
- `npx playwright install-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7ab7a761c83289584dd05a694cfba