### PR TITLE
fix: add keyboard focus style for tool cards

### DIFF
--- a/assets/css/visual-enhancements.css
+++ b/assets/css/visual-enhancements.css
@@ -40,10 +40,21 @@
 .tool-card:hover {
   border-color: var(--primary);
   transform: translateY(-8px) scale(1.02);
-  box-shadow: 
+  box-shadow:
     0 20px 40px rgba(0, 0, 0, 0.2),
     0 0 0 1px rgba(255, 107, 53, 0.2),
     0 0 30px rgba(255, 107, 53, 0.15);
+}
+
+.tool-card:focus-visible {
+  border-color: var(--primary);
+  transform: translateY(-8px) scale(1.02);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(255, 107, 53, 0.2),
+    0 0 30px rgba(255, 107, 53, 0.15);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .tool-card:hover .tool-icon {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lighthouse": "lhci autorun --config=.lighthouserc.json",
     "perf-check": "node scripts/performance-monitor.js --check",
     "perf-report": "node scripts/performance-monitor.js --report",
-    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && node tests/protein-calculator.test.js && node tests/t10-calculator.test.js && npm run perf-check"
+    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && node tests/protein-calculator.test.js && node tests/t10-calculator.test.js && node tests/tool-card.tab.test.js && npm run perf-check"
   },
   "devDependencies": {
     "@lhci/cli": "^0.12.0",

--- a/tests/tool-card.tab.test.js
+++ b/tests/tool-card.tab.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const path = require('path');
+const httpServer = require('http-server');
+const { chromium } = require('playwright');
+
+(async () => {
+  const server = httpServer.createServer({ root: path.join(__dirname, '..') });
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.server.address().port;
+  const baseUrl = `http://localhost:${port}/`;
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(baseUrl);
+  await page.waitForSelector('.tool-grid a.tool-card', { state: 'attached' });
+
+  // Ensure no tabindex attributes
+  const hasTabindex = await page.$$eval('.tool-grid a.tool-card', els =>
+    els.some(el => el.hasAttribute('tabindex'))
+  );
+  assert.strictEqual(hasTabindex, false, 'tool cards should not have tabindex');
+
+  await page.focus('body');
+
+  async function focusNextCard(expectedHref) {
+    for (let i = 0; i < 10; i++) {
+      const activeHref = await page.evaluate(() => document.activeElement.getAttribute('href'));
+      if (activeHref === expectedHref) return;
+      await page.keyboard.press('Tab');
+    }
+    const activeHrefFinal = await page.evaluate(() => document.activeElement.getAttribute('href'));
+    assert.strictEqual(activeHrefFinal, expectedHref, `expected focus on ${expectedHref}`);
+  }
+
+  const hrefs = [
+    '/pages/protein-farm-calculator.html',
+    '/pages/T10-calculator.html',
+    '/pages/team-builder.html'
+  ];
+
+  for (const href of hrefs) {
+    await focusNextCard(href);
+    // Move to next element for subsequent call
+    await page.keyboard.press('Tab');
+  }
+
+  // Shift+Tab should move focus back to previous card
+  await page.keyboard.press('Shift+Tab');
+  const backHref = await page.evaluate(() => document.activeElement.getAttribute('href'));
+  assert.strictEqual(backHref, '/pages/team-builder.html');
+  await page.keyboard.press('Shift+Tab');
+  const secondHref = await page.evaluate(() => document.activeElement.getAttribute('href'));
+  assert.strictEqual(secondHref, '/pages/T10-calculator.html');
+
+  await browser.close();
+  server.close();
+  console.log('Tool card keyboard navigation test passed');
+})();


### PR DESCRIPTION
## Summary
- style tool cards with `:focus-visible` to match hover state
- cover card tab order with a new Playwright test

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aefdfca0832881bc29bacd131556