### PR TITLE
[goal:accessibility-protein-calculator] fix(pages): label protein farm fields

### DIFF
--- a/pages/protein-farm-calculator.html
+++ b/pages/protein-farm-calculator.html
@@ -54,7 +54,7 @@
 
           <form id="proteinFarmForm" novalidate>
           <div class="target-section">
-            <label class="control-label">Missing Immune Protein for Next Upgrade</label>
+            <label for="targetAmount" class="control-label">Missing Immune Protein for Next Upgrade</label>
             <div class="control-description">
               Enter the amount shown in red letters on your progress bar. This
               represents how much immune protein you still need to collect for
@@ -67,7 +67,7 @@
 
           <div class="farm-grid">
             <div class="farm-item" id="farm1-container">
-              <div class="farm-name">Protein Farm I</div>
+              <label for="farm1" class="farm-name">Protein Farm I</label>
               <select id="farm1" class="form-select">
                 <!-- Options populated by JavaScript -->
               </select>
@@ -75,7 +75,7 @@
             </div>
 
             <div class="farm-item" id="farm2-container">
-              <div class="farm-name">Protein Farm II</div>
+              <label for="farm2" class="farm-name">Protein Farm II</label>
               <select id="farm2" class="form-select">
                 <option value="0">Not Built</option>
                 <!-- Options populated by JavaScript -->
@@ -84,7 +84,7 @@
             </div>
 
             <div class="farm-item" id="farm3-container">
-              <div class="farm-name">Protein Farm III</div>
+              <label for="farm3" class="farm-name">Protein Farm III</label>
               <select id="farm3" class="form-select">
                 <option value="0">Not Built</option>
                 <!-- Options populated by JavaScript -->
@@ -93,7 +93,7 @@
             </div>
 
             <div class="farm-item" id="farm4-container">
-              <div class="farm-name">Protein Farm IV</div>
+              <label for="farm4" class="farm-name">Protein Farm IV</label>
               <select id="farm4" class="form-select">
                 <option value="0">Not Built</option>
                 <!-- Options populated by JavaScript -->
@@ -102,7 +102,7 @@
             </div>
 
             <div class="farm-item" id="farm5-container">
-              <div class="farm-name">Protein Farm V</div>
+              <label for="farm5" class="farm-name">Protein Farm V</label>
               <select id="farm5" class="form-select">
                 <option value="0">Not Built</option>
                 <!-- Options populated by JavaScript -->


### PR DESCRIPTION
## Summary
- add missing `for` attribute to target amount label in protein farm calculator
- convert farm name headings to labels so farm level selects are accessible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b072335c8328a31cf805eb02917f