### PR TITLE
fix: label site search input for screen readers

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -138,9 +138,10 @@ class SiteSearch {
         searchContainer.innerHTML = `
             <div class="search-wrapper">
                 <div class="search-input-wrapper">
-                    <input 
-                        type="text" 
-                        id="site-search" 
+                    <label for="site-search" class="sr-only">Search the site</label>
+                    <input
+                        type="text"
+                        id="site-search"
                         placeholder="Search tools, guides..."
                         autocomplete="off"
                         class="search-input"


### PR DESCRIPTION
## What changed
- add screen-reader-only label before the search input so assistive tech can announce it

## Checklist
- [ ] SW cache bumped?
- [ ] Lighthouse CI ≥ threshold?
- [ ] A11y ≥ 90?

## Testing
- `npm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b1e62bec83289b14484b505a872d