### PR TITLE
chore: regenerate pages list and add update script

### DIFF
--- a/assets/pages.json
+++ b/assets/pages.json
@@ -1,11 +1,11 @@
 [
   {
-    "title": "All Tools - Coming Soon",
-    "href": "/pages/tools.html"
-  },
-  {
     "title": "All Guides - Coming Soon",
     "href": "/pages/guides.html"
+  },
+  {
+    "title": "All Tools - Coming Soon",
+    "href": "/pages/tools.html"
   },
   {
     "title": "Alliance Rules - Last War: Survival",
@@ -84,7 +84,7 @@
     "href": "/pages/season3.html"
   },
   {
-    "title": "Season Guides - Last War Tools",
+    "title": "Seasons - Last War Tools",
     "href": "/pages/seasons.html"
   },
   {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lighthouse": "lhci autorun --config=.lighthouserc.json",
     "perf-check": "node scripts/performance-monitor.js --check",
     "perf-report": "node scripts/performance-monitor.js --report",
-    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && node tests/protein-calculator.test.js && node tests/t10-calculator.test.js && node tests/tool-card.tab.test.js && npm run perf-check"
+    "test": "node tests/url-normalize.test.js && node tests/nav.unit.test.js && node tests/nav.render.test.js && node tests/nav.e2e.test.js && node tests/nav.playwright.test.js && node tests/protein-calculator.test.js && node tests/t10-calculator.test.js && node tests/tool-card.tab.test.js && npm run perf-check",
+    "generate:pages": "node scripts/generate-pages-json.js"
   },
   "devDependencies": {
     "@lhci/cli": "^0.12.0",


### PR DESCRIPTION
## Summary
- regenerate assets/pages.json via generate-pages-json
- add npm script to sync pages list

## Testing
- `npm test` *(fails: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b70421e0832886979dffbe172dc6