### PR TITLE
Shorten title and add canonical tag for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,10 @@
     <link rel="preload" href="https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="preload" href="https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com">
-    <title>LastWar Tools - Strategic Command Center for Last War: Survival</title>
+    <title>LastWar Tools – Strategy Center</title>
     <meta name="description"
         content="The ultimate strategic toolkit for Last War: Survival. Interactive calculators, comprehensive guides, and real-time tools to dominate every season.">
+    <link rel="canonical" href="https://tooltician.com/" />
     <meta http-equiv="Content-Security-Policy"
         content="default-src 'self';
                  script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com;
@@ -44,7 +45,7 @@
     <noscript><link rel="stylesheet" href="/assets/css/styles.min.css"></noscript>
 
     <!-- Open Graph -->
-    <meta property="og:title" content="LastWar Tools - Strategic Command Center">
+    <meta property="og:title" content="LastWar Tools – Strategy Center">
     <meta property="og:description"
         content="Interactive calculators, guides, and strategic tools for Last War: Survival">
     <meta property="og:type" content="website">


### PR DESCRIPTION
## Summary
- keep home page title under 60 characters
- add canonical URL to head for search engines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8adf76e248328800b536d8674ab75