### PR TITLE
fix: shorten season4 title

### DIFF
--- a/assets/pages.json
+++ b/assets/pages.json
@@ -52,7 +52,7 @@
     "href": "/pages/T10-calculator.html"
   },
   {
-    "title": "Last War: Survival Season 4 Guide - Evernight Isle Strategies & Best Heroes 2025",
+    "title": "Season 4 Evernight Isle Guide – Last War: Survival",
     "href": "/pages/season4.html"
   },
   {

--- a/pages/season4.html
+++ b/pages/season4.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="../assets/css/styles.min.css" />
 
     <!-- SEO Meta Tags -->
-    <title>Last War: Survival Season 4 Guide - Evernight Isle Strategies & Best Heroes 2025</title>
+    <title>Season 4 Evernight Isle Guide – Last War: Survival</title>
     <meta name="description"
         content="Complete Season 4 Evernight Isle guide for Last War: Survival. Best heroes, formation strategies, F2P tips, and advanced tactics to dominate the darkness." />
     <meta name="keywords"


### PR DESCRIPTION
## Summary
- shorten Season 4 guide title for SEO

## Testing
- `bash scripts/run_tests.sh` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b01e5c0c83289da8fb744f98c122