### PR TITLE
Add canonical link to heroes page

### DIFF
--- a/pages/heroes.html
+++ b/pages/heroes.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="../assets/css/styles.min.css" />
   <meta name="description" content="Hero classes and tier list for Last War: Survival." />
   <title>Heroes &amp; Tier List - Last War Tools</title>
+  <link rel="canonical" href="https://tooltician.com/pages/heroes.html" />
 
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TV9L6C3VN7"></script>


### PR DESCRIPTION
## Summary
- add canonical URL metadata for Heroes page to improve search indexing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b48448b88328907181cb8038ac03