### PR TITLE
Add offline page description meta tag

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Offline notice for LastWar Tools—reconnect to use calculators and guides." />
   <title>Offline - Last War Tools</title>
   <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- add description meta tag to offline page to clarify offline usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b62d28b883289abcaca5f0e1e6f0