### PR TITLE
Remove redundant robots disallow rules

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,9 +3,6 @@ Allow: /
 
 # Block common bot/crawler noise while allowing important crawling
 Disallow: /*.json$
-Disallow: /*.xml$
-Disallow: /assets/js/
-Disallow: /assets/css/
 
 # Allow important assets for indexing
 Allow: /assets/images/


### PR DESCRIPTION
## Summary
- allow XML and JS/CSS assets to be crawled by removing unneeded disallow entries
- keep sitemap reference for search engines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8270b348328ac83b9ba025faa88