### PR TITLE
Exclude non-live directories from sitemap

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -6,6 +6,10 @@ const path = require('path');
 // Configuration
 const baseURL = 'https://tooltician.com/';
 const outputPath = 'sitemap.xml';
+// Directories to exclude from the sitemap
+const excludedDirs = ['node_modules', 'backups', 'partials'];
+// Specific HTML files to exclude
+const excludedFiles = ['404.html'];
 
 // Priority mappings based on page type
 const priorityMap = {
@@ -51,10 +55,10 @@ function scanForHTMLFiles(dir, baseDir = '') {
         const relativePath = path.join(baseDir, item);
         const stat = fs.statSync(fullPath);
 
-        if (stat.isDirectory() && !item.startsWith('.') && item !== 'node_modules') {
+        if (stat.isDirectory() && !item.startsWith('.') && !excludedDirs.includes(item)) {
             // Recursively scan subdirectories
             files.push(...scanForHTMLFiles(fullPath, relativePath));
-        } else if (stat.isFile() && item.endsWith('.html')) {
+        } else if (stat.isFile() && item.endsWith('.html') && !excludedFiles.includes(relativePath)) {
             files.push({
                 path: relativePath,
                 fullPath: fullPath,

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,36 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://tooltician.com/404.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/backups/automation_20250813_190517/partials/nav.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/backups/automation_20250814_124220/partials/footer.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/backups/frontend_overhaul_20250814_132145/index.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/backups/frontend_overhaul_20250814_132145/partials/nav.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://tooltician.com/index.html</loc>
     <lastmod>2025-08-22</lastmod>
     <changefreq>weekly</changefreq>
@@ -179,17 +149,5 @@
     <lastmod>2025-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/partials/footer.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://tooltician.com/partials/nav.html</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- ignore `backups` and `partials` directories when generating sitemap
- skip `404.html` so only live pages are listed
- regenerate `sitemap.xml` with updated logic and lastmod dates

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba1806248328a4a7a62468eb3a54