### PR TITLE
Add schema markup for site search and guides

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,19 @@
         gtag('js', new Date());
         gtag('config', 'G-TV9L6C3VN7');
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://tooltician.com/",
+      "name": "LastWar Tools – Strategy Center",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://tooltician.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
     <script defer src="/assets/js/theme.js"></script>
 </head>
 

--- a/pages/alliances.html
+++ b/pages/alliances.html
@@ -25,6 +25,28 @@
 
     gtag('config', 'G-TV9L6C3VN7');
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://tooltician.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Alliances", "item": "https://tooltician.com/pages/alliances.html"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Alliances & Social Play Guide",
+        "description": "Guide to alliances in Last War: Survival - benefits, events and best practices.",
+        "author": {"@type": "Organization", "name": "LastWar Tools"},
+        "publisher": {"@type": "Organization", "name": "LastWar Tools"},
+        "mainEntityOfPage": {"@type": "WebPage", "@id": "https://tooltician.com/pages/alliances.html"}
+      }
+    ]
+  }
+  </script>
 
   <script defer src="../assets/js/theme.js"></script>
 </head>

--- a/pages/base-building.html
+++ b/pages/base-building.html
@@ -25,6 +25,28 @@
 
     gtag('config', 'G-TV9L6C3VN7');
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://tooltician.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Base Building", "item": "https://tooltician.com/pages/base-building.html"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Base Building & Development Guide",
+        "description": "Comprehensive guide to base building and development in Last War: Survival.",
+        "author": {"@type": "Organization", "name": "LastWar Tools"},
+        "publisher": {"@type": "Organization", "name": "LastWar Tools"},
+        "mainEntityOfPage": {"@type": "WebPage", "@id": "https://tooltician.com/pages/base-building.html"}
+      }
+    ]
+  }
+  </script>
 
   <script defer src="../assets/js/theme.js"></script>
 </head>

--- a/pages/heroes.html
+++ b/pages/heroes.html
@@ -26,6 +26,28 @@
 
     gtag('config', 'G-TV9L6C3VN7');
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://tooltician.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Heroes & Tier List", "item": "https://tooltician.com/pages/heroes.html"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Heroes & Tier List Guide",
+        "description": "Hero classes and tier list for Last War: Survival.",
+        "author": {"@type": "Organization", "name": "LastWar Tools"},
+        "publisher": {"@type": "Organization", "name": "LastWar Tools"},
+        "mainEntityOfPage": {"@type": "WebPage", "@id": "https://tooltician.com/pages/heroes.html"}
+      }
+    ]
+  }
+  </script>
 
   <script defer src="../assets/js/theme.js"></script>
 </head>

--- a/pages/season4.html
+++ b/pages/season4.html
@@ -38,6 +38,28 @@
 
         gtag('config', 'G-TV9L6C3VN7');
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://tooltician.com/"},
+            {"@type": "ListItem", "position": 2, "name": "Season 4 Guide", "item": "https://tooltician.com/pages/season4.html"}
+          ]
+        },
+        {
+          "@type": "Article",
+          "headline": "Season 4: Evernight Isle Guide",
+          "description": "Complete Season 4 Evernight Isle guide for Last War: Survival. Best heroes, formation strategies, F2P tips, and advanced tactics to dominate the darkness.",
+          "author": {"@type": "Organization", "name": "LastWar Tools"},
+          "publisher": {"@type": "Organization", "name": "LastWar Tools"},
+          "mainEntityOfPage": {"@type": "WebPage", "@id": "https://tooltician.com/pages/season4.html"}
+        }
+      ]
+    }
+    </script>
 
   <script defer src="../assets/js/theme.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- add WebSite schema with SearchAction to homepage
- add Article and BreadcrumbList structured data to base-building, heroes, season4, and alliances guides

## Testing
- `npx playwright install-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8bb55492c83289c49d62f3de64dac