### PR TITLE
Fix workflow to build Jekyll site from my-site directory

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -30,6 +30,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: my-site/Gemfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +47,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        working-directory: my-site
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --destination ../_site
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- point Pages workflow at the Jekyll sources in `my-site`
- ensure bundler uses the correct Gemfile and outputs to the expected `_site`

## Testing
- `bundle exec jekyll build --destination ../_site` *(fails: bundler: command not found: jekyll)*
- `npm test` *(fails: executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c3d7d1948328a771b122dc9b1aac