### PR TITLE
Fix Jekyll build path for GitHub Pages workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -30,8 +30,6 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: my-site/Gemfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,6 +40,7 @@ jobs:
           ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+          working-directory: my-site
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- run bundler inside `my-site` so Jekyll is installed

## Testing
- `bundle exec jekyll build --destination ../_site`
- `npm test` *(fails: npx playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c68e843483288509c3ed890611e1