### PR TITLE
Populate tools page with calculators

### DIFF
--- a/assets/pages.json
+++ b/assets/pages.json
@@ -4,7 +4,7 @@
     "href": "/pages/guides.html"
   },
   {
-    "title": "All Tools - Coming Soon",
+    "title": "All Tools - Last War Tools",
     "href": "/pages/tools.html"
   },
   {
@@ -52,10 +52,6 @@
     "href": "/pages/T10-calculator.html"
   },
   {
-    "title": "Season 4 Evernight Isle Guide – Last War: Survival",
-    "href": "/pages/season4.html"
-  },
-  {
     "title": "Last War: Survival Team Builder - Interactive Formation Tool & Hero Calculator",
     "href": "/pages/team-builder.html"
   },
@@ -82,6 +78,10 @@
   {
     "title": "Season 3 - Coming Soon",
     "href": "/pages/season3.html"
+  },
+  {
+    "title": "Season 4 Evernight Isle Guide – Last War: Survival",
+    "href": "/pages/season4.html"
   },
   {
     "title": "Seasons - Last War Tools",

--- a/pages/tools.html
+++ b/pages/tools.html
@@ -165,7 +165,7 @@
   
     
   <link rel="stylesheet" href="../assets/css/styles.min.css?v=20250829-PRO1" />
-  <title>All Tools - Coming Soon</title>
+  <title>All Tools - Last War Tools</title>
   <script defer src="../assets/js/theme.js?v=20250828"></script>
 </head>
 <body>
@@ -175,7 +175,95 @@
   </header>
   <main class="container content" role="main" id="main-content">
     <h1>All Tools</h1>
-    <p>Coming soon.</p>
+    <div class="tool-grid">
+      <a class="tool-card gaming-border fade-in" style="animation-delay: 0.1s;" href="/pages/protein-farm-calculator.html"
+        onkeydown="if(event.key === ' ') { event.preventDefault(); this.click(); }">
+        <div class="tool-icon float-animation">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M15.75 15.75V18M8.25 11.25H8.2575V11.2575H8.25V11.25ZM8.25 13.5H8.2575V13.5075H8.25V13.5ZM8.25 15.75H8.2575V15.7575H8.25V15.75ZM8.25 18H8.2575V18.0075H8.25V18ZM10.7476 11.25H10.7551V11.2575H10.7476V11.25ZM10.7476 13.5H10.7551V13.5075H10.7476V13.5ZM10.7476 15.75H10.7551V15.7575H10.7476V15.75ZM10.7476 18H10.7551V18.0075H10.7476V18ZM13.2524 11.25H13.2599V11.2575H13.2524V11.25ZM13.2524 13.5H13.2599V13.5075H13.2524V13.5ZM13.2524 15.75H13.2599V15.7575H13.2524V15.75ZM13.2524 18H13.2599V18.0075H13.2524V18ZM15.75 11.25H15.7575V11.2575H15.75V11.25ZM15.75 13.5H15.7575V13.5075H15.75V13.5ZM8.25 6H15.75V8.25H8.25V6ZM12 2.25C10.108 2.25 8.24156 2.35947 6.40668 2.57241C5.30608 2.70014 4.5 3.649 4.5 4.75699V19.5C4.5 20.7426 5.50736 21.75 6.75 21.75H17.25C18.4926 21.75 19.5 20.7426 19.5 19.5V4.75699C19.5 3.649 18.6939 2.70014 17.5933 2.57241C15.7584 2.35947 13.892 2.25 12 2.25Z" />
+          </svg>
+        </div>
+        <div class="tool-category">Calculator</div>
+        <h3>Protein Farm Calculator</h3>
+        <p class="tool-description">Optimize your protein production with precision calculations for maximum efficiency and resource allocation.</p>
+        <div class="tool-stats">
+          <span class="tool-stat">Instant Results</span>
+          <span class="tool-stat">Precision Accurate</span>
+          <span class="tool-stat">Optimized Output</span>
+        </div>
+        <div class="progress-bar">
+          <div class="progress-fill" style="width: 95%;"></div>
+        </div>
+        <span class="btn-enhanced">Calculate Now</span>
+      </a>
+
+      <a class="tool-card gaming-border fade-in" style="animation-delay: 0.2s;" href="/pages/T10-calculator.html"
+        onkeydown="if(event.key === ' ') { event.preventDefault(); this.click(); }">
+        <div class="tool-icon float-animation" style="animation-delay: 0.5s;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 2h12" />
+            <path d="M9 2v6l-4 7v5h14v-5l-4-7V2" />
+          </svg>
+        </div>
+        <div class="tool-category">Research</div>
+        <h3>Tier 10 Research</h3>
+        <p class="tool-description">Plan your research progression and calculate exact requirements for T10 troops and advanced technologies.</p>
+        <div class="tool-stats">
+          <span class="tool-stat">Advanced Planning</span>
+          <span class="tool-stat">Time Optimization</span>
+          <span class="tool-stat">Resource Efficient</span>
+        </div>
+        <div class="progress-bar">
+          <div class="progress-fill" style="width: 88%;"></div>
+        </div>
+        <span class="btn-enhanced">Research Now</span>
+      </a>
+
+      <a class="tool-card gaming-border fade-in" style="animation-delay: 0.3s;" href="/pages/team-builder.html"
+        onkeydown="if(event.key === ' ') { event.preventDefault(); this.click(); }">
+        <div class="tool-icon float-animation" style="animation-delay: 1s;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2l7 4v6c0 5-3.5 9-7 10-3.5-1-7-5-7-10V6l7-4z" />
+          </svg>
+        </div>
+        <div class="tool-category">Strategy</div>
+        <h3>Team Builder</h3>
+        <p class="tool-description">Create optimal team compositions and formations for maximum combat effectiveness in any situation.</p>
+        <div class="tool-stats">
+          <span class="tool-stat">Victory Focused</span>
+          <span class="tool-stat">Real-time Analysis</span>
+          <span class="tool-stat">Meta Optimized</span>
+        </div>
+        <div class="progress-bar">
+          <div class="progress-fill" style="width: 92%;"></div>
+        </div>
+        <span class="btn-enhanced">Build Team</span>
+      </a>
+
+      <a class="tool-card gaming-border fade-in" style="animation-delay: 0.4s;" href="/pages/event-tracker.html"
+        onkeydown="if(event.key === ' ') { event.preventDefault(); this.click(); }">
+        <div class="tool-icon float-animation" style="animation-delay: 1.5s;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+            <line x1="16" y1="2" x2="16" y2="6"></line>
+            <line x1="8" y1="2" x2="8" y2="6"></line>
+            <line x1="3" y1="10" x2="21" y2="10"></line>
+          </svg>
+        </div>
+        <div class="tool-category">Tracker</div>
+        <h3>Event Tracker</h3>
+        <p class="tool-description">Stay on top of game events and plan your strategy. Coming soon.</p>
+        <div class="tool-stats">
+          <span class="tool-stat">Stay Updated</span>
+          <span class="tool-stat">Plan Ahead</span>
+          <span class="tool-stat">Coming Soon</span>
+        </div>
+        <div class="progress-bar">
+          <div class="progress-fill" style="width: 70%;"></div>
+        </div>
+        <span class="btn-enhanced">View Tracker</span>
+      </a>
+    </div>
   </main>
   <footer id="footer-placeholder"></footer>
   <script src="../assets/js/script.js?v=20250828" defer></script>


### PR DESCRIPTION
## Summary
- list available calculators on the tools page and include an event tracker placeholder
- refresh pages.json with updated tools page title

## Testing
- `node scripts/generate-pages-json.js`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b621c58f6c8328a79cbcbe58c13d23