### PR TITLE
fix: enable top-level navigation links

### DIFF
--- a/my-site/_data/navigation.yml
+++ b/my-site/_data/navigation.yml
@@ -2,6 +2,7 @@ main:
   - title: "Home"
     url: "/"
   - title: "Tools"
+    url: "/pages/tools.html"
     children:
       - title: "Protein Farm Calculator"
         url: "/pages/protein-farm-calculator.html"
@@ -14,6 +15,7 @@ main:
       - title: "All Tools"
         url: "/pages/tools.html"
   - title: "Guides"
+    url: "/pages/guides.html"
     children:
       - title: "Heroes & Tier List"
         url: "/pages/heroes.html"
@@ -40,6 +42,7 @@ main:
       - title: "All Guides"
         url: "/pages/guides.html"
   - title: "Community"
+    url: "/pages/discord.html"
     children:
       - title: "Join Discord"
         url: "/pages/discord.html"


### PR DESCRIPTION
## Summary
- add URLs for Tools, Guides, and Community in site navigation so menu items are clickable

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b62a91f9cc8328874363804a6131ca