### PR TITLE
Add html-proofer and document Jekyll build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ npm run serve
 
 The site will be available at `http://localhost:3000`.
 
+### Building the site
+
+To generate the static site without starting the development server run:
+
+```bash
+cd my-site
+bundle exec jekyll build
+```
+
+You can also serve the site directly with Jekyll:
+
+```bash
+cd my-site
+bundle exec jekyll serve
+```
+
+### Styling overrides
+
+Minimal Mistakes can be customised through SCSS overrides. Add new partials
+under `my-site/_sass/` and import them from `my-site/assets/css/main.scss`.
+This keeps custom styles separate from the theme and makes future updates
+easier.
+
 ## Development
 
 Content is written in Markdown within the `my-site` directory and built by Jekyll. For the previous hand-built HTML version, run `npm run serve:legacy`.

--- a/my-site/Gemfile
+++ b/my-site/Gemfile
@@ -7,3 +7,8 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
+
+# HTMLProofer is used in development to verify links and images in the
+# generated site. It is not part of the runtime build but helps catch
+# broken references during testing.
+gem "html-proofer", group: :test

--- a/my-site/Gemfile.lock
+++ b/my-site/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (8.0.2.1)
       base64
       benchmark (>= 0.3)
@@ -16,6 +17,13 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    afm (1.0.0)
+    async (2.28.1)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -27,6 +35,10 @@ GEM
     commonmarker (0.23.11)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    console (1.33.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     dnsruby (1.72.2)
       simpleidn (~> 0.2.1)
@@ -55,6 +67,10 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -109,12 +125,23 @@ GEM
       octokit (>= 4, < 8)
       public_suffix (>= 3.0, < 6.0)
       typhoeus (~> 1.3)
+    hashery (2.1.2)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.0.10)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-event (1.13.0)
     jekyll (3.10.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -236,6 +263,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
+    metrics (0.14.0)
     mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
@@ -268,13 +296,21 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (5.1.1)
     racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.2)
     rouge (3.30.0)
+    ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -289,6 +325,9 @@ GEM
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    traces (0.18.1)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     typhoeus (1.5.0)
       ethon (>= 0.9.0, < 0.16.0)
     tzinfo (2.0.6)
@@ -296,6 +335,8 @@ GEM
     unicode-display_width (1.8.0)
     uri (1.0.3)
     webrick (1.9.1)
+    yell (2.2.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   aarch64-linux-android
@@ -320,6 +361,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  html-proofer
   jekyll-include-cache
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary
- add html-proofer dependency for link checking
- document build commands and SCSS override strategy

## Testing
- `bundle exec jekyll build`
- `bundle exec htmlproofer ./_site` *(fails: missing images and fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b72c4fca5c83289849afb95e1086c9