### PR TITLE
Add Minimal Mistakes main stylesheet and refine build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Install Ruby gems and start the Jekyll development server:
 
 ```bash
 bundle install
-npm run serve
+bundle exec jekyll serve
 ```
 
-The site will be available at `http://localhost:3000`.
+The site will be available at `http://localhost:4000`.
 
 ### Building the site
 
@@ -21,18 +21,11 @@ To generate the static site without starting the development server run:
 bundle exec jekyll build
 ```
 
-You can also serve the site directly with Jekyll:
-
-```bash
-bundle exec jekyll serve
-```
-
 ### Styling overrides
 
 Minimal Mistakes can be customised through SCSS overrides. Add new partials
-under `_sass/` and import them from `assets/css/styles.scss`.
-This keeps custom styles separate from the theme and makes future updates
-easier.
+under `_sass/overrides/` and import them from `assets/css/main.scss`.
+This keeps custom styles separate from the theme and makes future updates easier.
 
 After building the site you can check for broken links and images with:
 

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,9 @@ exclude:
   - Gemfile.lock
   - node_modules
   - vendor
+  - backups
+  - tests
+  - docs
 
 # Collections and defaults can be added here in the future to organise
 # posts or other content.  For now we rely on individual pages.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,5 @@
+---
+# Only the main Sass file needs front matter
+---
+@import "minimal-mistakes/skins/dark";
+@import "minimal-mistakes";


### PR DESCRIPTION
## Summary
- exclude backups, tests, and docs from Jekyll build
- add `assets/css/main.scss` to load Minimal Mistakes dark skin
- document local build and style override workflow in README

## Impact
- prevents obsolete directories from being published or checked, simplifying builds
- ensures site compiles with theme-provided styles for consistent UX

## Testing
- `bundle exec jekyll build`
- `bundle exec htmlproofer ./_site/index.html --disable-external`
- `bundle exec htmlproofer ./_site/about/index.html --disable-external --root-dir ./_site`


------
https://chatgpt.com/codex/tasks/task_e_68b73a6abac88328a069cd7a0a14f37c