### PR TITLE
feat: align config with Minimal Mistakes and add blog scaffold

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
+gem "jekyll-redirect-from", group: :jekyll_plugins
 
 # HTMLProofer is used in development to verify links and images in the
 # generated site. It is not part of the runtime build but helps catch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,7 @@ DEPENDENCIES
   github-pages
   html-proofer
   jekyll-include-cache
+  jekyll-redirect-from
 
 BUNDLED WITH
    2.7.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This keeps custom styles separate from the theme and makes future updates easier
 After building the site you can check for broken links and images with:
 
 ```bash
-bundle exec htmlproofer ./_site
+bundle exec htmlproofer ./_site --disable-external
 ```
 
 ## Development

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-include-cache
   - jekyll-remote-theme
+  - jekyll-redirect-from
 
 # Exclude non‑site files from the build.  These files are only used
 # locally and should not be published.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -44,5 +44,7 @@ main:
         url: "/pages/discord.html"
       - title: "Community Rules"
         url: "/pages/rules.html"
+  - title: "Blog"
+    url: "/blog/"
   - title: "About"
     url: "/about/"

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,0 +1,7 @@
+---
+layout: home
+title: "Blog"
+permalink: /blog/
+---
+
+No posts yet.


### PR DESCRIPTION
## Summary
- add jekyll-redirect-from plugin and enable in config
- expose blog in navigation with placeholder index
- document htmlproofer usage for local checks

## Testing
- `bundle exec jekyll build`
- `bundle exec htmlproofer ./_site --disable-external` *(fails: missing images, broken anchors)*


------
https://chatgpt.com/codex/tasks/task_e_68b73cef899c8328882105a0cacdb7b6