### PR TITLE
feat(nav): add accessible dropdown menus

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,8 +1,10 @@
 main:
   - title: "Home"
     url: "/"
+    icon: "🏠"
   - title: "Tools"
     url: "/pages/tools.html"
+    icon: "🛠️"
     children:
       - title: "Protein Farm Calculator"
         url: "/pages/protein-farm-calculator.html"
@@ -14,6 +16,7 @@ main:
         url: "/pages/event-tracker.html"
   - title: "Guides"
     url: "/pages/guides.html"
+    icon: "📚"
     children:
       - title: "Heroes & Tier List"
         url: "/pages/heroes.html"
@@ -39,6 +42,7 @@ main:
         url: "/pages/pre-season.html"
   - title: "Community"
     url: "/pages/discord.html"
+    icon: "💡"
     children:
       - title: "Join Discord"
         url: "/pages/discord.html"
@@ -46,5 +50,7 @@ main:
         url: "/pages/rules.html"
   - title: "Blog"
     url: "/blog/"
+    icon: "📝"
   - title: "About"
     url: "/about/"
+    icon: "ℹ️"

--- a/_sass/overrides/_nav.scss
+++ b/_sass/overrides/_nav.scss
@@ -1,0 +1,55 @@
+/* Navigation overrides */
+.nav-container {
+  font-size: 1rem;
+
+  .nav-link,
+  .submenu-toggle {
+    padding: 0.625rem 0.875rem;
+    line-height: 1.5;
+  }
+
+  .submenu-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    min-width: 40px;
+    min-height: 40px;
+  }
+
+  .nav-item {
+    position: relative;
+
+    &.dropdown {
+      .dropdown-menu {
+        position: absolute;
+        left: 0;
+        top: 100%;
+        display: none;
+        background: var(--mm-color-bg, #1e1e1e);
+        border-radius: 0.5rem;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+        padding: 0.375rem;
+        list-style: none;
+        min-width: 12rem;
+
+        li > a {
+          display: block;
+          padding: 0.5rem 0.75rem;
+          line-height: 1.45;
+          font-size: 0.875rem;
+        }
+      }
+
+      &.active .dropdown-menu,
+      .dropdown-menu.show {
+        display: block;
+      }
+    }
+  }
+
+  a:focus,
+  .submenu-toggle:focus {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -110,15 +110,15 @@
             });
         }
 
-        document.querySelectorAll('.nav-item.dropdown > .nav-link').forEach(link => {
-            link.addEventListener('click', (e) => {
+        document.querySelectorAll('.nav-item.dropdown > .submenu-toggle').forEach(btn => {
+            btn.addEventListener('click', (e) => {
                 if (window.innerWidth <= 768) {
                     e.preventDefault();
-                    const dropdown = link.parentElement;
+                    const dropdown = btn.parentElement;
                     const dropdownMenu = dropdown.querySelector('.dropdown-menu');
                     dropdown.classList.toggle('active');
                     dropdownMenu.classList.toggle('show');
-                    link.setAttribute('aria-expanded', String(dropdown.classList.contains('active')));
+                    btn.setAttribute('aria-expanded', String(dropdown.classList.contains('active')));
                 }
             });
         });
@@ -126,14 +126,20 @@
         document.querySelectorAll('.nav-item.dropdown').forEach(item => {
             const handleEnter = () => {
                 if (window.innerWidth > 768) {
-                    const link = item.querySelector('.nav-link');
-                    link.setAttribute('aria-expanded', 'true');
+                    const toggle = item.querySelector('.submenu-toggle');
+                    if (toggle) toggle.setAttribute('aria-expanded', 'true');
+                    item.classList.add('active');
+                    const menu = item.querySelector('.dropdown-menu');
+                    if (menu) menu.classList.add('show');
                 }
             };
             const handleLeave = () => {
                 if (window.innerWidth > 768) {
-                    const link = item.querySelector('.nav-link');
-                    link.setAttribute('aria-expanded', 'false');
+                    const toggle = item.querySelector('.submenu-toggle');
+                    if (toggle) toggle.setAttribute('aria-expanded', 'false');
+                    item.classList.remove('active');
+                    const menu = item.querySelector('.dropdown-menu');
+                    if (menu) menu.classList.remove('show');
                 }
             };
             item.addEventListener('mouseenter', handleEnter);
@@ -158,15 +164,19 @@
                 } else if (dropdown && (key === 'Enter' || key === ' ' || key === 'ArrowDown')) {
                     e.preventDefault();
                     dropdown.classList.add('active');
-                    dropdown.querySelector('.dropdown-menu').classList.add('show');
-                    link.setAttribute('aria-expanded', 'true');
-                    const first = dropdown.querySelector('.dropdown-menu a');
+                    const menu = dropdown.querySelector('.dropdown-menu');
+                    if (menu) menu.classList.add('show');
+                    const toggle = dropdown.querySelector('.submenu-toggle');
+                    if (toggle) toggle.setAttribute('aria-expanded', 'true');
+                    const first = menu ? menu.querySelector('a') : null;
                     if (first) first.focus();
                 } else if (key === 'Escape') {
                     if (dropdown) {
                         dropdown.classList.remove('active');
-                        dropdown.querySelector('.dropdown-menu').classList.remove('show');
-                        link.setAttribute('aria-expanded', 'false');
+                        const menu = dropdown.querySelector('.dropdown-menu');
+                        if (menu) menu.classList.remove('show');
+                        const toggle = dropdown.querySelector('.submenu-toggle');
+                        if (toggle) toggle.setAttribute('aria-expanded', 'false');
                     }
                 }
             });
@@ -186,9 +196,10 @@
                     const dropdown = a.closest('.nav-item.dropdown');
                     dropdown.classList.remove('active');
                     dropdown.querySelector('.dropdown-menu').classList.remove('show');
+                    const toggle = dropdown.querySelector('.submenu-toggle');
+                    if (toggle) toggle.setAttribute('aria-expanded', 'false');
                     const link = dropdown.querySelector('.nav-link');
-                    link.setAttribute('aria-expanded', 'false');
-                    link.focus();
+                    if (link) link.focus();
                 } else if (e.key === 'ArrowRight') {
                     e.preventDefault();
                     const next = a.closest('.nav-item.dropdown').nextElementSibling;
@@ -206,7 +217,7 @@
                 if (navMenu) navMenu.classList.remove('active');
                 if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
                 document.querySelectorAll('.nav-item.dropdown').forEach(dd => dd.classList.remove('active'));
-                document.querySelectorAll('.nav-item.dropdown > .nav-link').forEach(link => link.setAttribute('aria-expanded', 'false'));
+                document.querySelectorAll('.nav-item.dropdown .submenu-toggle').forEach(btn => btn.setAttribute('aria-expanded', 'false'));
                 document.querySelectorAll('.dropdown-menu').forEach(menu => menu.classList.remove('show'));
             }
         });

--- a/docs/navigation-update.md
+++ b/docs/navigation-update.md
@@ -1,0 +1,37 @@
+# Navigation Update
+
+## Menu hierarchy
+- Home
+- Tools
+  - Protein Farm Calculator
+  - T10 Research Calculator
+  - Team Builder
+  - Event Tracker
+- Guides
+  - Heroes & Tier List
+  - Base Building
+  - Alliance Strategy
+  - Resource Management
+  - Events Guide
+  - Tips & Tricks
+  - Season 4
+  - Season 3
+  - Season 2
+  - Season 1
+  - Pre-Season
+- Community
+  - Join Discord
+  - Community Rules
+- Blog
+- About
+
+## Before / After
+<!-- TODO: add screenshots showing previous index pages and new dropdown navigation -->
+
+## Accessibility
+- Keyboard navigation with arrow keys and Escape
+- Clear focus outlines
+- ARIA labels (`aria-expanded`, `aria-controls`)
+
+## Index pages
+Existing category index pages remain available and can be converted to rich collections if needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@lhci/cli": "^0.12.0",
         "http-server": "^14.1.1",
         "jquery": "^3.7.1",
+        "js-yaml": "^4.1.0",
         "jsdom": "^23.0.0",
+        "liquidjs": "^10.13.0",
         "playwright": "^1.48.0"
       }
     },
@@ -195,6 +197,30 @@
         "js-yaml": "^3.13.1",
         "lighthouse": "10.1.0",
         "tree-kill": "^1.2.1"
+      }
+    },
+    "node_modules/@lhci/utils/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@lhci/utils/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -579,14 +605,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -998,6 +1021,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/compressible": {
@@ -2423,14 +2456,13 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2873,6 +2905,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/liquidjs": {
+      "version": "10.21.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.1.tgz",
+      "integrity": "sha512-NZXmCwv3RG5nire3fmIn9HsOyJX3vo+ptp0yaXUHAMzSNBhx74Hm+dAGJvscUA6lNqbLuYfXgNavRQ9UbUJhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "http-server": "^14.1.1",
     "jsdom": "^23.0.0",
     "jquery": "^3.7.1",
-    "playwright": "^1.48.0"
+    "playwright": "^1.48.0",
+    "js-yaml": "^4.1.0",
+    "liquidjs": "^10.13.0"
   }
 }

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,6 +1,9 @@
+---
+layout: null
+---
 <div class="nav-container">
   <nav class="main-nav" aria-label="Primary">
-    <!-- Logo/Brand (links home) -->
+    <!-- Logo/Brand -->
     <div class="nav-brand">
       <a href="/" class="brand-link">
         <span class="brand-icon">⚔️</span>
@@ -10,7 +13,7 @@
 
     <!-- Search Integration -->
     <div class="nav-search" id="nav-search">
-      <!-- Search will be injected here by search.js -->
+      <!-- Search injected by search.js -->
     </div>
 
     <!-- Mobile Toggle -->
@@ -22,66 +25,24 @@
 
     <!-- Navigation Menu -->
     <ul class="nav-menu" id="navMenu">
-      <li class="nav-item">
-        <a class="nav-link" href="/" aria-current="page">
-          <span class="nav-icon">🏠</span>
-          <span class="nav-text">Home</span>
+      {% for item in site.data.navigation.main %}
+      <li class="nav-item{% if item.children %} dropdown{% endif %}">
+        <a class="nav-link" href="{{ item.url }}">
+          {% if item.icon %}<span class="nav-icon">{{ item.icon }}</span>{% endif %}
+          <span class="nav-text">{{ item.title }}</span>
         </a>
-      </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
-          <span class="nav-icon">🛠️</span>
-          <span class="nav-text">Tools</span>
+        {% if item.children %}
+        <button class="submenu-toggle" aria-expanded="false" aria-controls="submenu-{{ forloop.index }}" aria-label="Toggle {{ item.title }} menu">
           <span class="dropdown-arrow">▼</span>
-        </a>
-        <ul class="dropdown-menu">
-          <li><a href="/pages/protein-farm-calculator.html">Protein Farm Calculator</a></li>
-          <li><a href="/pages/T10-calculator.html">T10 Research Calculator</a></li>
-          <li><a href="/pages/team-builder.html">Team Builder</a></li>
-          <li><a href="/pages/event-tracker.html">Event Tracker</a></li>
-          <li class="dropdown-divider" role="separator"></li>
-          <li><a href="/pages/tools.html">All Tools</a></li>
+        </button>
+        <ul class="dropdown-menu" id="submenu-{{ forloop.index }}" role="menu">
+          {% for child in item.children %}
+          <li role="none"><a href="{{ child.url }}" role="menuitem">{{ child.title }}</a></li>
+          {% endfor %}
         </ul>
+        {% endif %}
       </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
-          <span class="nav-icon">📚</span>
-          <span class="nav-text">Guides</span>
-          <span class="dropdown-arrow">▼</span>
-        </a>
-        <ul class="dropdown-menu">
-          <li><a href="/pages/heroes.html">Heroes &amp; Tier List</a></li>
-          <li><a href="/pages/base-building.html">Base Building</a></li>
-          <li><a href="/pages/alliances.html">Alliance Strategy</a></li>
-          <li><a href="/pages/resources.html">Resource Management</a></li>
-          <li><a href="/pages/events.html">Events Guide</a></li>
-          <li><a href="/pages/tips.html">Tips &amp; Tricks</a></li>
-          <li class="dropdown-divider" role="separator"></li>
-          <li><a href="/pages/season4.html">Season 4 <span class="badge current">Current</span></a></li>
-          <li><a href="/pages/season3.html">Season 3</a></li>
-          <li><a href="/pages/Season2.html">Season 2</a></li>
-          <li><a href="/pages/season1.html">Season 1</a></li>
-          <li><a href="/pages/pre-season.html">Pre-Season</a></li>
-          <li><a href="/pages/seasons.html">All Season Guides</a></li>
-          <li class="dropdown-divider" role="separator"></li>
-          <li><a href="/pages/guides.html">All Guides</a></li>
-        </ul>
-      </li>
-
-      <li class="nav-item dropdown">
-        <a class="nav-link" href="#" aria-haspopup="true" aria-expanded="false">
-          <span class="nav-icon">💡</span>
-          <span class="nav-text">Community</span>
-          <span class="dropdown-arrow">▼</span>
-        </a>
-        <ul class="dropdown-menu">
-          <li><a href="/pages/discord.html" class="featured-link">💬 Join Discord</a></li>
-          <li><a href="/pages/rules.html">Community Rules</a></li>
-        </ul>
-      </li>
-
+      {% endfor %}
     </ul>
 
     <div class="theme-toggle-container">
@@ -90,5 +51,4 @@
       </button>
     </div>
   </nav>
-  </div>
-
+</div>

--- a/tests/nav.e2e.test.js
+++ b/tests/nav.e2e.test.js
@@ -2,9 +2,15 @@ const assert = require('assert');
 const { JSDOM } = require('jsdom');
 const fs = require('fs');
 const path = require('path');
-const navHtml = fs.readFileSync(path.join(__dirname, '../partials/nav.html'), 'utf8');
+const { Liquid } = require('liquidjs');
+const yaml = require('js-yaml');
 
-const dom = new JSDOM(`<div class="nav-container">${navHtml}</div>`, { url: 'http://example.com/', pretendToBeVisual: true });
+const engine = new Liquid();
+const tpl = fs.readFileSync(path.join(__dirname, '../partials/nav.html'), 'utf8');
+const navData = yaml.load(fs.readFileSync(path.join(__dirname, '../_data/navigation.yml'), 'utf8'));
+const rendered = engine.parseAndRenderSync(tpl, { site: { data: { navigation: navData } } });
+
+const dom = new JSDOM(`<div class="nav-container">${rendered}</div>`, { url: 'http://example.com/', pretendToBeVisual: true });
 const window = dom.window;
 
 global.window = window;
@@ -14,21 +20,22 @@ const { initNavigationInteractions } = require('../assets/js/script.js');
 initNavigationInteractions();
 
 const tools = window.document.querySelector('.nav-item.dropdown');
+const toggle = tools.querySelector('.submenu-toggle');
 
 // Hover test
 tools.dispatchEvent(new window.Event('mouseover', { bubbles: true }));
-assert.strictEqual(tools.querySelector('.nav-link').getAttribute('aria-expanded'), 'true');
+assert.strictEqual(toggle.getAttribute('aria-expanded'), 'true');
 tools.dispatchEvent(new window.Event('mouseout', { bubbles: true }));
-assert.strictEqual(tools.querySelector('.nav-link').getAttribute('aria-expanded'), 'false');
+assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
 
 // Mobile click test
 window.innerWidth = 500;
-const link = tools.querySelector('.nav-link');
-link.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+toggle.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
 assert(tools.classList.contains('active') && tools.querySelector('.dropdown-menu').classList.contains('show'));
 
 // Keyboard navigation
 window.innerWidth = 1200;
+const link = tools.querySelector('.nav-link');
 link.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
 assert(window.document.activeElement.textContent.trim().startsWith('Protein Farm'));
 

--- a/tests/nav.playwright.test.js
+++ b/tests/nav.playwright.test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const path = require('path');
+const fs = require('fs');
+const yaml = require('js-yaml');
+const { Liquid } = require('liquidjs');
 const httpServer = require('http-server');
 const { chromium } = require('playwright');
 
@@ -9,8 +12,16 @@ const { chromium } = require('playwright');
   const port = server.server.address().port;
   const baseUrl = `http://localhost:${port}/`;
 
+  const engine = new Liquid();
+  const navTpl = fs.readFileSync(path.join(__dirname, '../partials/nav.html'), 'utf8');
+  const navData = yaml.load(fs.readFileSync(path.join(__dirname, '../_data/navigation.yml'), 'utf8'));
+  const renderedNav = engine.parseAndRenderSync(navTpl, { site: { data: { navigation: navData } } });
+
   const browser = await chromium.launch();
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.route('**/partials/nav.html', route => {
+    route.fulfill({ body: renderedNav, contentType: 'text/html' });
+  });
   await page.goto(baseUrl + 'pages/guides.html');
   await page.waitForSelector('.nav-container a', { state: 'attached' });
   const desktopHeight = await page.evaluate(() => document.querySelector('.nav-container').offsetHeight);


### PR DESCRIPTION
## Summary
- build navbar dropdowns from `navigation.yml`
- add responsive submenu styling and focus states
- wire keyboard and aria controls for improved accessibility

## Testing
- `node tests/nav.unit.test.js`
- `node tests/nav.render.test.js`
- `node tests/nav.e2e.test.js`
- `node tests/protein-calculator.test.js && node tests/t10-calculator.test.js && node tests/url-normalize.test.js` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b74209bcec8328a70c9edc32fcd7bc