### PR TITLE
Improve navbar dropdown accessibility and styles

### DIFF
--- a/_sass/overrides/_nav.scss
+++ b/_sass/overrides/_nav.scss
@@ -1,19 +1,47 @@
 /* Navigation overrides */
+
 .nav-container {
   font-size: 1rem;
 
-  .nav-link,
-  .submenu-toggle {
+  .nav-link {
     padding: 0.625rem 0.875rem;
-    line-height: 1.5;
+    line-height: 1.4;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--mm-color-fg, #ffffff);
+    text-decoration: none;
+    transition: background 0.2s ease;
+
+    &:hover,
+    &:focus {
+      background: rgba(255, 255, 255, 0.1);
+      color: var(--mm-color-fg, #ffffff);
+    }
+
+    &:active {
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    &[aria-current="page"] {
+      background: var(--mm-color-primary, #00ff88);
+      color: var(--mm-color-bg, #000000);
+    }
   }
 
   .submenu-toggle {
+    padding: 0.625rem 0.875rem;
+    line-height: 1.4;
     background: none;
     border: none;
     cursor: pointer;
     min-width: 40px;
     min-height: 40px;
+    transition: background 0.2s ease;
+
+    &:hover,
+    &:focus {
+      background: rgba(255, 255, 255, 0.1);
+    }
   }
 
   .nav-item {
@@ -31,12 +59,20 @@
         padding: 0.375rem;
         list-style: none;
         min-width: 12rem;
+        z-index: 1000;
 
         li > a {
           display: block;
           padding: 0.5rem 0.75rem;
           line-height: 1.45;
           font-size: 0.875rem;
+          color: var(--mm-color-fg, #ffffff);
+          border-radius: 0.25rem;
+
+          &:hover,
+          &:focus {
+            background: rgba(255, 255, 255, 0.1);
+          }
         }
       }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -112,14 +112,26 @@
 
         document.querySelectorAll('.nav-item.dropdown > .submenu-toggle').forEach(btn => {
             btn.addEventListener('click', (e) => {
-                if (window.innerWidth <= 768) {
-                    e.preventDefault();
-                    const dropdown = btn.parentElement;
-                    const dropdownMenu = dropdown.querySelector('.dropdown-menu');
-                    dropdown.classList.toggle('active');
-                    dropdownMenu.classList.toggle('show');
-                    btn.setAttribute('aria-expanded', String(dropdown.classList.contains('active')));
+                e.preventDefault();
+                const dropdown = btn.parentElement;
+                const dropdownMenu = dropdown.querySelector('.dropdown-menu');
+                const isActive = dropdown.classList.toggle('active');
+                dropdownMenu.classList.toggle('show', isActive);
+
+                // close other open dropdowns
+                if (isActive) {
+                    document.querySelectorAll('.nav-item.dropdown').forEach(d => {
+                        if (d !== dropdown) {
+                            d.classList.remove('active');
+                            const menu = d.querySelector('.dropdown-menu');
+                            if (menu) menu.classList.remove('show');
+                            const t = d.querySelector('.submenu-toggle');
+                            if (t) t.setAttribute('aria-expanded', 'false');
+                        }
+                    });
                 }
+
+                btn.setAttribute('aria-expanded', String(isActive));
             });
         });
 
@@ -212,13 +224,23 @@
             });
         });
 
+        const closeAll = () => {
+            if (navMenu) navMenu.classList.remove('active');
+            if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
+            document.querySelectorAll('.nav-item.dropdown').forEach(dd => dd.classList.remove('active'));
+            document.querySelectorAll('.nav-item.dropdown .submenu-toggle').forEach(btn => btn.setAttribute('aria-expanded', 'false'));
+            document.querySelectorAll('.dropdown-menu').forEach(menu => menu.classList.remove('show'));
+        };
+
         document.addEventListener('click', (e) => {
             if (!e.target.closest('.nav-container')) {
-                if (navMenu) navMenu.classList.remove('active');
-                if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
-                document.querySelectorAll('.nav-item.dropdown').forEach(dd => dd.classList.remove('active'));
-                document.querySelectorAll('.nav-item.dropdown .submenu-toggle').forEach(btn => btn.setAttribute('aria-expanded', 'false'));
-                document.querySelectorAll('.dropdown-menu').forEach(menu => menu.classList.remove('show'));
+                closeAll();
+            }
+        });
+
+        document.addEventListener('focusin', (e) => {
+            if (!e.target.closest('.nav-container')) {
+                closeAll();
             }
         });
 

--- a/docs/navigation-update.md
+++ b/docs/navigation-update.md
@@ -26,12 +26,14 @@
 - About
 
 ## Before / After
+-Dropdown menus replace the old index pages that listed links vertically.
 <!-- TODO: add screenshots showing previous index pages and new dropdown navigation -->
 
 ## Accessibility
 - Keyboard navigation with arrow keys and Escape
 - Clear focus outlines
 - ARIA labels (`aria-expanded`, `aria-controls`)
+- Menus close when clicking or tabbing outside
 
 ## Index pages
-Existing category index pages remain available and can be converted to rich collections if needed.
+Existing category index pages remain available for SEO and may be converted into richer collections if needed.


### PR DESCRIPTION
## Summary
- allow desktop users to toggle dropdowns via caret button and close menus on focus loss
- refine navigation typography, spacing, and hover/focus/active states in dark theme
- document dropdown hierarchy and accessibility notes

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b745bfff1c832887f12c9b6bc68df7