### PR TITLE
[goal:a11y-fixes] fix: improve focus outline and hero alt fallback

### DIFF
--- a/_sass/overrides/_custom.scss
+++ b/_sass/overrides/_custom.scss
@@ -20,3 +20,9 @@
   z-index: 10000;
   border-radius: 0 0 4px 0;
 }
+
+/* Global focus style */
+:focus-visible {
+  outline: 3px solid var(--mm-color-primary, #00ff88);
+  outline-offset: 3px;
+}

--- a/pages/team-builder.html
+++ b/pages/team-builder.html
@@ -445,7 +445,7 @@
             <div class="hero-card" data-hero="${hero.name}">
                 <div class="hero-tier ${hero.tier.toLowerCase()}">${hero.tier}</div>
                 <div class="hero-image">
-                    <img src="../assets/images/heroes/${hero.image}" alt="${hero.name}" width="128" height="128" loading="lazy" onerror="this.src='../assets/images/hero-placeholder.jpg'">
+                    <img src="../assets/images/heroes/${hero.image}" alt="${hero.name || 'Hero portrait'}" width="128" height="128" loading="lazy" onerror="this.src='../assets/images/hero-placeholder.jpg'">
                 </div>
                 <h3>${hero.name}</h3>
                 <div class="hero-details">
@@ -512,7 +512,7 @@
                     slot.innerHTML = `
                     <div class="slot-number">${index + 1}</div>
                     <div class="hero-in-slot">
-                        <img src="../assets/images/heroes/${hero.image}" alt="${hero.name}" width="128" height="128" loading="lazy" onerror="this.src='../assets/images/hero-placeholder.jpg'">
+                        <img src="../assets/images/heroes/${hero.image}" alt="${hero.name || 'Hero portrait'}" width="128" height="128" loading="lazy" onerror="this.src='../assets/images/hero-placeholder.jpg'">
                         <div class="hero-name">${hero.name}</div>
                         <div class="hero-role ${hero.role.toLowerCase()}">${hero.role}</div>
                     </div>


### PR DESCRIPTION
## What changed
- add global `:focus-visible` outline
- ensure team-builder hero images fall back to descriptive alt text

## Checklist
- [ ] SW cache bumped?
- [ ] Lighthouse CI ≥ threshold?
- [x] A11y ≥ 90?

## Validation
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75fea948083289f96e630f16d5a50