### PR TITLE
Enable navbar dropdowns on hover and click

### DIFF
--- a/_sass/overrides/_nav.scss
+++ b/_sass/overrides/_nav.scss
@@ -76,6 +76,10 @@
         }
       }
 
+      &:hover > .dropdown-menu {
+        display: block;
+      }
+
       &.active .dropdown-menu,
       .dropdown-menu.show {
         display: block;

--- a/assets/css/styles.min.scss
+++ b/assets/css/styles.min.scss
@@ -2,4 +2,5 @@
 ---
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
 @import "minimal-mistakes";
+@import "overrides/nav";
 @import "overrides/custom";

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -2,4 +2,5 @@
 ---
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
 @import "minimal-mistakes";
+@import "overrides/nav";
 @import "overrides/custom";

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -158,6 +158,31 @@
             item.addEventListener('mouseleave', handleLeave);
             item.addEventListener('mouseover', handleEnter);
             item.addEventListener('mouseout', handleLeave);
+
+            const link = item.querySelector('> .nav-link');
+            if (link) {
+                link.addEventListener('click', (e) => {
+                    const dropdown = item;
+                    const menu = dropdown.querySelector('.dropdown-menu');
+                    const toggle = dropdown.querySelector('.submenu-toggle');
+                    const isActive = dropdown.classList.contains('active');
+                    if (!isActive) {
+                        e.preventDefault();
+                        dropdown.classList.add('active');
+                        if (menu) menu.classList.add('show');
+                        if (toggle) toggle.setAttribute('aria-expanded', 'true');
+                        document.querySelectorAll('.nav-item.dropdown').forEach(d => {
+                            if (d !== dropdown) {
+                                d.classList.remove('active');
+                                const dm = d.querySelector('.dropdown-menu');
+                                if (dm) dm.classList.remove('show');
+                                const t = d.querySelector('.submenu-toggle');
+                                if (t) t.setAttribute('aria-expanded', 'false');
+                            }
+                        });
+                    }
+                });
+            }
         });
 
         document.querySelectorAll('.nav-item > .nav-link').forEach(link => {


### PR DESCRIPTION
## Summary
- display dropdown menus on hover across navbar categories
- toggle submenu on first click to avoid redirecting to index pages

## Testing
- `bash scripts/run_tests.sh` *(partial: suite exited early; see note)*
- `node tests/nav.playwright.test.js` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b7640db698832880b47aa3b8bf0384