### PR TITLE
Fix missing navigation styles

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,5 +1,7 @@
 ---
 # Only the main Sass file needs front matter
 ---
-@import "minimal-mistakes/skins/dark";
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
 @import "minimal-mistakes";
+@import "overrides/nav";
+@import "overrides/custom";


### PR DESCRIPTION
## Summary
- load nav and custom overrides through main stylesheet so dropdown menus display

## Testing
- `bundle exec jekyll build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7712b7f388328905de0faba905cf8