### PR TITLE
Ensure navigation menu loads consistently across pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,10 @@ plugins:
   - jekyll-remote-theme
   - jekyll-redirect-from
 
+# Load site-wide scripts after the main bundle
+after_footer_scripts:
+  - /assets/js/script.js
+
 # Exclude non‑site files from the build.  These files are only used
 # locally and should not be published.
 exclude:

--- a/_sass/overrides/_nav.scss
+++ b/_sass/overrides/_nav.scss
@@ -1,7 +1,19 @@
 /* Navigation overrides */
 
+/* Hide default theme masthead to use custom navigation */
+.masthead {
+  display: none;
+}
+
 .nav-container {
   font-size: 1rem;
+
+  .nav-menu {
+    list-style: none;
+    display: flex;
+    margin: 0;
+    padding: 0;
+  }
 
   .nav-link {
     padding: 0.625rem 0.875rem;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -31,6 +31,18 @@
             .catch(() => {})
             .finally(() => {
                 if (!navExists) {
+                    let navContainer = document.getElementById('nav-placeholder');
+                    if (!navContainer) {
+                        const masthead = document.querySelector('.masthead');
+                        if (masthead) masthead.remove();
+                        const header = document.createElement('header');
+                        header.className = 'site-header';
+                        navContainer = document.createElement('div');
+                        navContainer.id = 'nav-placeholder';
+                        header.appendChild(navContainer);
+                        document.body.prepend(header);
+                    }
+
                     fetch(partialPaths.nav)
                         .then(r => {
                             if (!r.ok) throw r;


### PR DESCRIPTION
## Summary
- load custom navigation script on every page
- dynamically inject nav placeholder when missing and remove default masthead
- style custom menu horizontally and hide original masthead

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Liquid syntax error in assets/pages.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7968fcea4832894760f45da7adde2