### PR TITLE
Fix pages.json Liquid filter syntax

### DIFF
--- a/assets/pages.json
+++ b/assets/pages.json
@@ -2,8 +2,11 @@
 layout: null
 permalink: /assets/pages.json
 ---
-[
-{%- assign pages = site.pages | where_exp: "p", "p.path contains '/pages/' and p.title" | sort: "title" -%}
+[ 
+{%- assign pages = site.pages
+     | where_exp: "p", "p.path contains '/pages/'"
+     | where_exp: "p", "p.title"
+     | sort: "title" -%}
 {%- for p in pages -%}
   {"title": {{ p.title | jsonify }}, "href": {{ p.url | jsonify }} }{%- unless forloop.last -%},{%- endunless -%}
 {%- endfor -%}


### PR DESCRIPTION
## Summary
- separate `where_exp` filters in `assets/pages.json` to avoid Liquid parse error

## Testing
- `bundle exec jekyll build`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b798c1a0c48328acda01397e23428d