### PR TITLE
fix(nav): restore calculators and guides

### DIFF
--- a/_calculators/event-tracker.md
+++ b/_calculators/event-tracker.md
@@ -2,10 +2,10 @@
 layout: single
 title: "Event Tracker"
 permalink: /calculators/event-tracker/
+hidden: true
 ---
 
     <h1>Event Tracker</h1>
     <p>Coming soon.</p>
   <footer id="footer-placeholder"></footer>
   <script src="../assets/js/script.js?v=20250828" defer></script>
-

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,0 +1,48 @@
+{% capture logo_path %}{{ site.logo }}{% endcapture %}
+
+<div class="masthead">
+  <div class="masthead__inner-wrap">
+    <div class="masthead__menu">
+      <nav id="site-nav" class="greedy-nav">
+        {% unless logo_path == empty %}
+          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
+        {% endunless %}
+        <a class="site-title" href="{{ '/' | relative_url }}">
+          {{ site.masthead_title | default: site.title | escape_once | strip }}
+          {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle | escape_once | strip }}</span>{% endif %}
+        </a>
+        <ul class="visible-links">
+          {%- for link in site.data.navigation.main -%}
+            <li class="masthead__menu-item{% if link.children %} has-subnav{% endif %}">
+              <a
+                href="{{ link.url | relative_url }}"
+                {% if link.description %} title="{{ link.description }}"{% endif %}
+                {% if link.target %} target="{{ link.target }}"{% endif %}
+                {% if link.children %} aria-haspopup="true"{% endif %}>
+                {{ link.title }}
+              </a>
+              {% if link.children %}
+                <ul class="subnav">
+                  {% for child in link.children %}
+                    <li><a href="{{ child.url | relative_url }}">{{ child.title }}</a></li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </li>
+          {%- endfor -%}
+        </ul>
+        {% if site.search == true %}
+        <button class="search__toggle" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
+          <i class="fas fa-search"></i>
+        </button>
+        {% endif %}
+        <button class="greedy-nav__toggle hidden" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
+          <div class="navicon"></div>
+        </button>
+        <ul class="hidden-links hidden"></ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/_pages/calculators.md
+++ b/_pages/calculators.md
@@ -1,6 +1,13 @@
 ---
-layout: collection
+layout: single
 title: "Calculators"
 permalink: /calculators/
-collection: calculators
 ---
+
+{% for calc in site.calculators %}
+{% unless calc.hidden %}
+<div class="archive__item">
+  <h2 class="archive__item-title no_toc"><a href="{{ calc.url | relative_url }}">{{ calc.title }}</a></h2>
+</div>
+{% endunless %}
+{% endfor %}

--- a/_pages/guides.md
+++ b/_pages/guides.md
@@ -1,6 +1,11 @@
 ---
-layout: collection
+layout: single
 title: "Guides"
 permalink: /guides/
-collection: guides
 ---
+
+{% for guide in site.guides %}
+<div class="archive__item">
+  <h2 class="archive__item-title no_toc"><a href="{{ guide.url | relative_url }}">{{ guide.title }}</a></h2>
+</div>
+{% endfor %}

--- a/_sass/overrides/_custom.scss
+++ b/_sass/overrides/_custom.scss
@@ -26,3 +26,28 @@
   outline: 3px solid var(--mm-color-primary, #00ff88);
   outline-offset: 3px;
 }
+
+/* Dropdown navigation */
+.masthead__menu-item { position: relative; }
+.masthead__menu-item .subnav {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #1f242c;
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  min-width: 12rem;
+  border: 1px solid #343a40;
+  z-index: 1000;
+}
+.masthead__menu-item .subnav li { margin: 0; }
+.masthead__menu-item .subnav a {
+  display: block;
+  padding: 0.25rem 0.75rem;
+}
+.masthead__menu-item:hover > .subnav,
+.masthead__menu-item:focus-within > .subnav {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add dropdown navigation that exposes calculators and guides
- list calculator and guide pages directly
- hide unfinished event tracker from listings

## Testing
- `bundle exec jekyll build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b86a413a2c8328918adc685caf30dc